### PR TITLE
23.12.1-alpha

### DIFF
--- a/src/core/Zap.sol
+++ b/src/core/Zap.sol
@@ -25,7 +25,7 @@ contract Zap is Controllable, ReentrancyGuardUpgradeable, IZap {
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     /// @inheritdoc IControllable
-    string public constant VERSION = "1.0.0";
+    string public constant VERSION = "1.0.1";
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                      INITIALIZATION                        */
@@ -106,11 +106,11 @@ contract Zap is Controllable, ReentrancyGuardUpgradeable, IZap {
             revert NotAllowedDexAggregator(agg);
         }
 
-        IERC20(vault).safeTransferFrom(msg.sender, address(this), sharesToBurn);
+        // IERC20(vault).safeTransferFrom(msg.sender, address(this), sharesToBurn);
 
         address strategy = address(IVault(vault).strategy());
         address[] memory assets = IStrategy(strategy).assets();
-        uint[] memory amountsOut = IVault(vault).withdrawAssets(assets, sharesToBurn, minAssetAmountsOut);
+        uint[] memory amountsOut = IVault(vault).withdrawAssets(assets, sharesToBurn, minAssetAmountsOut, address(this), msg.sender);
 
         uint len = swapData.length;
         for (uint i; i < len; ++i) {

--- a/src/core/base/VaultBase.sol
+++ b/src/core/base/VaultBase.sol
@@ -29,7 +29,7 @@ abstract contract VaultBase is Controllable, ERC20Upgradeable, ReentrancyGuardUp
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     /// @dev Version of VaultBase implementation
-    string public constant VERSION_VAULT_BASE = "1.0.0";
+    string public constant VERSION_VAULT_BASE = "1.0.1";
 
     /// @dev Delay between deposits/transfers and withdrawals
     uint internal constant _WITHDRAW_REQUEST_BLOCKS = 5;
@@ -200,61 +200,18 @@ abstract contract VaultBase is Controllable, ERC20Upgradeable, ReentrancyGuardUp
         uint amountShares,
         uint[] memory minAssetAmountsOut
     ) external virtual nonReentrant returns (uint[] memory) {
-        if (amountShares == 0) {
-            revert IControllable.IncorrectZeroArgument();
-        }
-        if (amountShares > balanceOf(msg.sender)) {
-            revert NotEnoughBalanceToPay();
-        }
-        if (assets_.length != minAssetAmountsOut.length) {
-            revert IControllable.IncorrectArrayLength();
-        }
+        return _withdrawAssets(assets_, amountShares, minAssetAmountsOut, msg.sender, msg.sender);
+    }
 
-        VaultBaseStorage storage $ = _getVaultBaseStorage();
-        _beforeWithdraw($);
-
-        IStrategy _strategy = $.strategy;
-        uint localTotalSupply = totalSupply();
-        uint totalValue = _strategy.total();
-
-        uint[] memory amountsOut;
-        address underlying = _strategy.underlying();
-        //nosemgrep
-        bool isUnderlyingWithdrawal = assets_.length == 1 && underlying != address(0) && underlying == assets_[0];
-
-        // fuse is not triggered
-        if (totalValue > 0) {
-            uint value = amountShares * totalValue / localTotalSupply;
-            if (isUnderlyingWithdrawal) {
-                amountsOut = new uint[](1);
-                amountsOut[0] = value;
-                $.strategy.withdrawUnderlying(amountsOut[0], msg.sender);
-            } else {
-                amountsOut = $.strategy.withdrawAssets(assets_, value, msg.sender);
-            }
-        } else {
-            if (isUnderlyingWithdrawal) {
-                amountsOut = new uint[](1);
-                amountsOut[0] = amountShares * IERC20(underlying).balanceOf(address(_strategy)) / localTotalSupply;
-                $.strategy.withdrawUnderlying(amountsOut[0], msg.sender);
-            } else {
-                amountsOut = $.strategy.transferAssets(amountShares, localTotalSupply, msg.sender);
-            }
-        }
-
-        uint len = amountsOut.length;
-        //nosemgrep
-        for (uint i; i < len; ++i) {
-            if (amountsOut[i] < minAssetAmountsOut[i]) {
-                revert ExceedSlippageExactAsset(assets_[i], amountsOut[i], minAssetAmountsOut[i]);
-            }
-        }
-
-        _burn(msg.sender, amountShares);
-
-        emit WithdrawAssets(msg.sender, assets_, amountShares, amountsOut);
-
-        return amountsOut;
+    /// @inheritdoc IVault
+    function withdrawAssets(
+        address[] memory assets_,
+        uint amountShares,
+        uint[] memory minAssetAmountsOut,
+        address receiver,
+        address owner
+    ) external virtual nonReentrant returns (uint[] memory) {
+        return _withdrawAssets(assets_, amountShares, minAssetAmountsOut, receiver, owner);
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -465,19 +422,89 @@ abstract contract VaultBase is Controllable, ERC20Upgradeable, ReentrancyGuardUp
         }
     }
 
-    function _beforeWithdraw(VaultBaseStorage storage $) internal {
-        if ($.withdrawRequests[msg.sender] + _WITHDRAW_REQUEST_BLOCKS >= block.number) {
+    function _withdrawAssets(
+        address[] memory assets_,
+        uint amountShares,
+        uint[] memory minAssetAmountsOut,
+        address receiver,
+        address owner
+    ) internal virtual returns (uint[] memory) {
+        if (msg.sender != owner) {
+            _spendAllowance(owner, msg.sender, amountShares);
+        }
+
+        if (amountShares == 0) {
+            revert IControllable.IncorrectZeroArgument();
+        }
+        if (amountShares > balanceOf(owner)) {
+            revert NotEnoughBalanceToPay();
+        }
+        if (assets_.length != minAssetAmountsOut.length) {
+            revert IControllable.IncorrectArrayLength();
+        }
+
+        VaultBaseStorage storage $ = _getVaultBaseStorage();
+        _beforeWithdraw($, owner);
+
+        IStrategy _strategy = $.strategy;
+        uint localTotalSupply = totalSupply();
+        uint totalValue = _strategy.total();
+
+        uint[] memory amountsOut;
+
+        {
+        address underlying = _strategy.underlying();
+        //nosemgrep
+        bool isUnderlyingWithdrawal = assets_.length == 1 && underlying != address(0) && underlying == assets_[0];
+
+        // fuse is not triggered
+        if (totalValue > 0) {
+            uint value = amountShares * totalValue / localTotalSupply;
+            if (isUnderlyingWithdrawal) {
+                amountsOut = new uint[](1);
+                amountsOut[0] = value;
+                $.strategy.withdrawUnderlying(amountsOut[0], receiver);
+            } else {
+                amountsOut = $.strategy.withdrawAssets(assets_, value, receiver);
+            }
+        } else {
+            if (isUnderlyingWithdrawal) {
+                amountsOut = new uint[](1);
+                amountsOut[0] = amountShares * IERC20(underlying).balanceOf(address(_strategy)) / localTotalSupply;
+                $.strategy.withdrawUnderlying(amountsOut[0], receiver);
+            } else {
+                amountsOut = $.strategy.transferAssets(amountShares, localTotalSupply, receiver);
+            }
+        }
+
+        uint len = amountsOut.length;
+        //nosemgrep
+        for (uint i; i < len; ++i) {
+            if (amountsOut[i] < minAssetAmountsOut[i]) {
+                revert ExceedSlippageExactAsset(assets_[i], amountsOut[i], minAssetAmountsOut[i]);
+            }
+        }
+
+        }
+
+        _burn(owner, amountShares);
+
+        emit WithdrawAssets(msg.sender, owner, assets_, amountShares, amountsOut);
+
+        return amountsOut;
+    }
+
+    function _beforeWithdraw(VaultBaseStorage storage $, address owner) internal {
+        if ($.withdrawRequests[owner] + _WITHDRAW_REQUEST_BLOCKS >= block.number) {
             revert WaitAFewBlocks();
         }
-        $.withdrawRequests[msg.sender] = block.number;
+        $.withdrawRequests[owner] = block.number;
     }
 
     function _update(address from, address to, uint value) internal virtual override {
         super._update(from, to, value);
         VaultBaseStorage storage $ = _getVaultBaseStorage();
         $.withdrawRequests[from] = block.number;
-        if (to != IPlatform(platform()).zap()) {
-            $.withdrawRequests[to] = block.number;
-        }
+        $.withdrawRequests[to] = block.number;
     }
 }

--- a/src/core/vaults/CVault.sol
+++ b/src/core/vaults/CVault.sol
@@ -14,7 +14,7 @@ contract CVault is VaultBase {
     //region ----- Constants -----
 
     /// @dev Version of CVault implementation
-    string public constant VERSION = "1.0.0";
+    string public constant VERSION = "1.0.1";
 
     uint internal constant _UNIQUE_INIT_ADDRESSES = 1;
 

--- a/src/core/vaults/RMVault.sol
+++ b/src/core/vaults/RMVault.sol
@@ -21,7 +21,7 @@ contract RMVault is RVaultBase, IManagedVault {
     //region ----- Constants -----
 
     /// @dev Version of RMVault implementation
-    string public constant VERSION = "1.0.0";
+    string public constant VERSION = "1.0.1";
 
     uint internal constant _UNIQUE_INIT_ADDRESSES = 1;
 

--- a/src/core/vaults/RVault.sol
+++ b/src/core/vaults/RVault.sol
@@ -20,7 +20,7 @@ contract RVault is RVaultBase {
     //region ----- Constants -----
 
     /// @dev Version of RVault implementation
-    string public constant VERSION = "1.0.0";
+    string public constant VERSION = "1.0.1";
 
     uint public constant BB_TOKEN_DURATION = 86400 * 7;
 

--- a/src/interfaces/IVault.sol
+++ b/src/interfaces/IVault.sol
@@ -27,7 +27,7 @@ interface IVault is IERC165 {
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     event DepositAssets(address indexed account, address[] assets, uint[] amounts, uint mintAmount);
-    event WithdrawAssets(address indexed account, address[] assets, uint sharesAmount, uint[] amountsOut);
+    event WithdrawAssets(address indexed sender, address indexed owner, address[] assets, uint sharesAmount, uint[] amountsOut);
     event HardWorkGas(uint gasUsed, uint gasCost, bool compensated);
     event DoHardWorkOnDepositChanged(bool oldValue, bool newValue);
     event MaxSupply(uint maxShares);
@@ -179,6 +179,21 @@ interface IVault is IERC165 {
         address[] memory assets_,
         uint amountShares,
         uint[] memory minAssetAmountsOut
+    ) external returns (uint[] memory);
+
+    /// @dev Burning shares of vault and obtaining strategy assets.
+    /// @param assets_ Assets suitable for the strategy. Can be strategy assets, underlying asset or specific set of assets depending on strategy logic.
+    /// @param amountShares Shares amount for burning
+    /// @param minAssetAmountsOut Slippage tolerance. Minimal amounts of strategy assets that user must receive.
+    /// @param receiver Receiver of assets
+    /// @param owner Owner of vault shares
+    /// @return Amount of assets for withdraw. It's related to assets_ one-by-one.
+    function withdrawAssets(
+        address[] memory assets_,
+        uint amountShares,
+        uint[] memory minAssetAmountsOut,
+        address receiver,
+        address owner
     ) external returns (uint[] memory);
 
     /// @dev Setting of vault capacity

--- a/src/test/MockVaultUpgrade.sol
+++ b/src/test/MockVaultUpgrade.sol
@@ -76,6 +76,14 @@ contract MockVaultUpgrade is Controllable, ERC20Upgradeable, IVault {
         uint[] memory minAssetAmountsOut
     ) external returns (uint[] memory) {}
 
+    function withdrawAssets(
+        address[] memory assets_,
+        uint amountShares,
+        uint[] memory minAssetAmountsOut,
+        address receiver,
+        address owner
+    ) external returns (uint[] memory) {}
+
     function withdrawUnderlying(uint amountShares, uint minAmountOut) external {}
 
     function doHardWork() external {}

--- a/test/core/Vault.t.sol
+++ b/test/core/Vault.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.23;
 
+import {IERC20Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
 import {Test, console} from "forge-std/Test.sol";
 import "../../src/core/vaults/CVault.sol";
 import "../../src/core/proxy/Proxy.sol";
@@ -127,6 +128,16 @@ contract VaultTest is Test, FullMockSetup {
         vm.roll(block.number + 6);
 
         shares = vault.balanceOf(address(this));
+
+        vm.prank(address(100));
+        vm.expectRevert(abi.encodeWithSelector(
+            IERC20Errors.ERC20InsufficientAllowance.selector,
+            address(100),
+            0,
+            shares / 2
+        ));
+        vault.withdrawAssets(assets, shares / 2, new uint[](2), address(this), address(this));
+
         vault.withdrawAssets(assets, shares / 2, new uint[](2));
         vm.roll(block.number + 6);
 


### PR DESCRIPTION
## Upgrades

* `VaulBase` 1.0.1
* `CVault` 1.0.1
* `RVault` 1.0.1
* `RMVault` 1.0.1
* `Zap` 1.0.1

## Core interfaces

* `IVault.withdrawAssets` selector with `receiver` and `owner` arguments

## Security fixes

* `_update` hook in `VaultBase` has no exceptions when writing `$.withdrawRequests`