### PR TITLE
fix: coverage improve

### DIFF
--- a/src/strategies/QuickSwapStaticMerklFarmStrategy.sol
+++ b/src/strategies/QuickSwapStaticMerklFarmStrategy.sol
@@ -216,9 +216,7 @@ contract QuickSwapStaticMerklFarmStrategy is LPStrategyBase, FarmingStrategyBase
     }
 
     /// @inheritdoc IStrategy
-    function isHardWorkOnDepositAllowed() external pure returns (bool) {
-        return false;
-    }
+    function isHardWorkOnDepositAllowed() external pure returns (bool) {}
 
     /// @inheritdoc IStrategy
     function isReadyForHardWork() external view returns (bool isReady) {

--- a/test/strategies/QSMF.Polygon.t.sol
+++ b/test/strategies/QSMF.Polygon.t.sol
@@ -6,6 +6,7 @@ import "../base/UniversalTest.sol";
 
 contract QuickswapStaticMerklFarmStrategyTest is PolygonSetup, UniversalTest {
     function testQSMF() public universalTest {
+        // starategy push
         strategies.push(
             Strategy({
                 id: StrategyIdLib.QUICKSWAP_STATIC_MERKL_FARM,


### PR DESCRIPTION
improved coverage in src/strategies/QuickSwapStaticMerklFarmStrategy.sol as Lines: 100%(improved 0.76%) Statements: 99.47(improved 0.77%).
![image](https://github.com/stabilitydao/stability-contracts/assets/153700650/52248f91-39e1-4803-bece-82b3288ab535)
