### PR TITLE
389 factory upgrade

### DIFF
--- a/chains/ArbitrumLib.sol
+++ b/chains/ArbitrumLib.sol
@@ -170,10 +170,8 @@ library ArbitrumLib {
         //endregion -- Add farms -----
 
         //region ----- Deploy strategy logics -----
-        _addStrategyLogic(factory, StrategyIdLib.COMPOUND_FARM, address(new CompoundFarmStrategy()), true);
-        _addStrategyLogic(
-            factory, StrategyIdLib.GAMMA_UNISWAPV3_MERKL_FARM, address(new GammaUniswapV3MerklFarmStrategy()), true
-        );
+        factory.setStrategyImplementation(StrategyIdLib.COMPOUND_FARM, address(new CompoundFarmStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.GAMMA_UNISWAPV3_MERKL_FARM, address(new GammaUniswapV3MerklFarmStrategy()));
         LogDeployLib.logDeployStrategies(platform, showLog);
         //endregion -- Deploy strategy logics -----
 
@@ -271,10 +269,6 @@ library ArbitrumLib {
         farm.nums = new uint[](0);
         farm.ticks = new int24[](0);
         return farm;
-    }
-
-    function _addStrategyLogic(IFactory factory, string memory id, address implementation, bool farming) internal {
-        factory.setStrategyImplementation(id, address(implementation));
     }
 
     function testArbitrumLib() external {}

--- a/chains/ArbitrumLib.sol
+++ b/chains/ArbitrumLib.sol
@@ -274,17 +274,7 @@ library ArbitrumLib {
     }
 
     function _addStrategyLogic(IFactory factory, string memory id, address implementation, bool farming) internal {
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: id,
-                implementation: address(implementation),
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: farming,
-                tokenId: type(uint).max
-            }),
-            StrategyDeveloperLib.getDeveloper(id)
-        );
+        factory.setStrategyImplementation(id, address(implementation));
     }
 
     function testArbitrumLib() external {}

--- a/chains/BaseLib.sol
+++ b/chains/BaseLib.sol
@@ -273,17 +273,7 @@ library BaseLib {
     }
 
     function _addStrategyLogic(IFactory factory, string memory id, address implementation, bool farming) internal {
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: id,
-                implementation: address(implementation),
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: farming,
-                tokenId: type(uint).max
-            }),
-            StrategyDeveloperLib.getDeveloper(id)
-        );
+        factory.setStrategyImplementation(id, address(implementation));
     }
 
     function testChainLib() external {}

--- a/chains/BaseLib.sol
+++ b/chains/BaseLib.sol
@@ -163,10 +163,8 @@ library BaseLib {
         //endregion -- Add farms -----
 
         //region ----- Deploy strategy logics -----
-        _addStrategyLogic(factory, StrategyIdLib.COMPOUND_FARM, address(new CompoundFarmStrategy()), true);
-        _addStrategyLogic(
-            factory, StrategyIdLib.GAMMA_UNISWAPV3_MERKL_FARM, address(new GammaUniswapV3MerklFarmStrategy()), true
-        );
+        factory.setStrategyImplementation(StrategyIdLib.COMPOUND_FARM, address(new CompoundFarmStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.GAMMA_UNISWAPV3_MERKL_FARM, address(new GammaUniswapV3MerklFarmStrategy()));
         LogDeployLib.logDeployStrategies(platform, showLog);
         //endregion -- Deploy strategy logics -----
 
@@ -270,10 +268,6 @@ library BaseLib {
         farm.nums = new uint[](0);
         farm.ticks = new int24[](0);
         return farm;
-    }
-
-    function _addStrategyLogic(IFactory factory, string memory id, address implementation, bool farming) internal {
-        factory.setStrategyImplementation(id, address(implementation));
     }
 
     function testChainLib() external {}

--- a/chains/EthereumLib.sol
+++ b/chains/EthereumLib.sol
@@ -201,17 +201,7 @@ library EthereumLib {
     }
 
     function _addStrategyLogic(IFactory factory, string memory id, address implementation, bool farming) internal {
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: id,
-                implementation: address(implementation),
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: farming,
-                tokenId: type(uint).max
-            }),
-            StrategyDeveloperLib.getDeveloper(id)
-        );
+        factory.setStrategyImplementation(id, address(implementation));
     }
 
     function testEthereumLib() external {}

--- a/chains/EthereumLib.sol
+++ b/chains/EthereumLib.sol
@@ -135,7 +135,7 @@ library EthereumLib {
         //endregion
 
         //region ----- Deploy strategy logics -----
-        _addStrategyLogic(factory, StrategyIdLib.COMPOUND_FARM, address(new CompoundFarmStrategy()), true);
+        factory.setStrategyImplementation(StrategyIdLib.COMPOUND_FARM, address(new CompoundFarmStrategy()));
         LogDeployLib.logDeployStrategies(platform, showLog);
         //endregion
 
@@ -198,10 +198,6 @@ library EthereumLib {
         farm.nums = new uint[](0);
         farm.ticks = new int24[](0);
         return farm;
-    }
-
-    function _addStrategyLogic(IFactory factory, string memory id, address implementation, bool farming) internal {
-        factory.setStrategyImplementation(id, address(implementation));
     }
 
     function testEthereumLib() external {}

--- a/chains/PolygonLib.sol
+++ b/chains/PolygonLib.sol
@@ -713,17 +713,7 @@ library PolygonLib {
     }
 
     function _addStrategyLogic(IFactory factory, string memory id, address implementation, bool farming) internal {
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: id,
-                implementation: address(implementation),
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: farming,
-                tokenId: type(uint).max
-            }),
-            StrategyDeveloperLib.getDeveloper(id)
-        );
+        factory.setStrategyImplementation(id, address(implementation));
     }
 
     function testPolygonLib() external {}

--- a/chains/PolygonLib.sol
+++ b/chains/PolygonLib.sol
@@ -320,29 +320,16 @@ library PolygonLib {
         //endregion -- Add strategy available init params -----
 
         //region ----- Deploy strategy logics -----
-        _addStrategyLogic(
-            factory, StrategyIdLib.GAMMA_QUICKSWAP_MERKL_FARM, address(new GammaQuickSwapMerklFarmStrategy()), true
-        );
-        _addStrategyLogic(
-            factory, StrategyIdLib.QUICKSWAP_STATIC_MERKL_FARM, address(new QuickSwapStaticMerklFarmStrategy()), true
-        );
-        _addStrategyLogic(factory, StrategyIdLib.COMPOUND_FARM, address(new CompoundFarmStrategy()), true);
-        _addStrategyLogic(
-            factory,
-            StrategyIdLib.DEFIEDGE_QUICKSWAP_MERKL_FARM,
-            address(new DefiEdgeQuickSwapMerklFarmStrategy()),
-            true
-        );
-        _addStrategyLogic(
-            factory, StrategyIdLib.ICHI_QUICKSWAP_MERKL_FARM, address(new IchiQuickSwapMerklFarmStrategy()), true
-        );
-        _addStrategyLogic(factory, StrategyIdLib.ICHI_RETRO_MERKL_FARM, address(new IchiRetroMerklFarmStrategy()), true);
-        _addStrategyLogic(
-            factory, StrategyIdLib.GAMMA_RETRO_MERKL_FARM, address(new GammaRetroMerklFarmStrategy()), true
-        );
-        _addStrategyLogic(factory, StrategyIdLib.CURVE_CONVEX_FARM, address(new CurveConvexFarmStrategy()), true);
-        _addStrategyLogic(factory, StrategyIdLib.YEARN, address(new YearnStrategy()), false);
-        _addStrategyLogic(factory, StrategyIdLib.STEER_QUICKSWAP_MERKL_FARM, address(new SteerQuickSwapMerklFarmStrategy()), true);
+        factory.setStrategyImplementation(StrategyIdLib.GAMMA_QUICKSWAP_MERKL_FARM, address(new GammaQuickSwapMerklFarmStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.QUICKSWAP_STATIC_MERKL_FARM, address(new QuickSwapStaticMerklFarmStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.COMPOUND_FARM, address(new CompoundFarmStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.DEFIEDGE_QUICKSWAP_MERKL_FARM, address(new DefiEdgeQuickSwapMerklFarmStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.ICHI_QUICKSWAP_MERKL_FARM, address(new IchiQuickSwapMerklFarmStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.ICHI_RETRO_MERKL_FARM, address(new IchiRetroMerklFarmStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.GAMMA_RETRO_MERKL_FARM, address(new GammaRetroMerklFarmStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.CURVE_CONVEX_FARM, address(new CurveConvexFarmStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.YEARN, address(new YearnStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.STEER_QUICKSWAP_MERKL_FARM, address(new SteerQuickSwapMerklFarmStrategy()));
         LogDeployLib.logDeployStrategies(platform, showLog);
         //endregion -- Deploy strategy logics -----
 
@@ -710,10 +697,6 @@ library PolygonLib {
         address tokenOut
     ) internal pure returns (ISwapper.AddPoolData memory) {
         return ISwapper.AddPoolData({pool: pool, ammAdapterId: ammAdapterId, tokenIn: tokenIn, tokenOut: tokenOut});
-    }
-
-    function _addStrategyLogic(IFactory factory, string memory id, address implementation, bool farming) internal {
-        factory.setStrategyImplementation(id, address(implementation));
     }
 
     function testPolygonLib() external {}

--- a/chains/RealLib.sol
+++ b/chains/RealLib.sol
@@ -251,17 +251,7 @@ library RealLib {
     }
 
     function _addStrategyLogic(IFactory factory, string memory id, address implementation, bool farming) internal {
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: id,
-                implementation: address(implementation),
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: farming,
-                tokenId: type(uint).max
-            }),
-            StrategyDeveloperLib.getDeveloper(id)
-        );
+        factory.setStrategyImplementation(id, address(implementation));
     }
 
     function testChainLib() external {}

--- a/chains/RealLib.sol
+++ b/chains/RealLib.sol
@@ -162,7 +162,7 @@ library RealLib {
         //endregion -- Add farms -----
 
         //region ----- Deploy strategy logics -----
-        _addStrategyLogic(factory, StrategyIdLib.TRIDENT_PEARL_FARM, address(new TridentPearlFarmStrategy()), true);
+        factory.setStrategyImplementation(StrategyIdLib.TRIDENT_PEARL_FARM, address(new TridentPearlFarmStrategy()));
         LogDeployLib.logDeployStrategies(platform, showLog);
         //endregion -- Deploy strategy logics -----
 
@@ -248,10 +248,6 @@ library RealLib {
         address tokenOut
     ) internal pure returns (ISwapper.AddPoolData memory) {
         return ISwapper.AddPoolData({pool: pool, ammAdapterId: ammAdapterId, tokenIn: tokenIn, tokenOut: tokenOut});
-    }
-
-    function _addStrategyLogic(IFactory factory, string memory id, address implementation, bool farming) internal {
-        factory.setStrategyImplementation(id, address(implementation));
     }
 
     function testChainLib() external {}

--- a/chains/avalanche/AvalancheLib.sol
+++ b/chains/avalanche/AvalancheLib.sol
@@ -123,12 +123,11 @@ library AvalancheLib {
         //endregion -- Add strategy available init params -----
 
         //region ----- Deploy strategies  -----
-        _addStrategyLogic(factory, StrategyIdLib.SILO, address(new SiloStrategy()), false);
-        _addStrategyLogic(factory, StrategyIdLib.EULER, address(new EulerStrategy()), false);
-        _addStrategyLogic(factory, StrategyIdLib.AAVE, address(new AaveStrategy()), false);
-        _addStrategyLogic(factory, StrategyIdLib.EULER_MERKL_FARM, address(new EulerMerklFarmStrategy()), true);
-        _addStrategyLogic(factory, StrategyIdLib.SILO_MANAGED_MERKL_FARM, address(new SiloManagedMerklFarmStrategy()), true);
-        _addStrategyLogic(factory, StrategyIdLib.SILO_MERKL_FARM, address(new SiloMerklFarmStrategy()), true);
+        factory.setStrategyImplementation(StrategyIdLib.SILO, address(new SiloStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.EULER, address(new EulerStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.AAVE, address(new AaveStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.EULER_MERKL_FARM, address(new EulerMerklFarmStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.SILO_MANAGED_MERKL_FARM, address(new SiloManagedMerklFarmStrategy()));
         //endregion
 
         //region ----- Add DeX aggregators -----
@@ -208,10 +207,6 @@ library AvalancheLib {
         address tokenOut
     ) internal pure returns (ISwapper.AddPoolData memory) {
         return ISwapper.AddPoolData({pool: pool, ammAdapterId: ammAdapterId, tokenIn: tokenIn, tokenOut: tokenOut});
-    }
-
-    function _addStrategyLogic(IFactory factory, string memory id, address implementation, bool farming) internal {
-        factory.setStrategyImplementation(id, address(implementation));
     }
 
     function testChainDeployLib() external {}

--- a/chains/avalanche/AvalancheLib.sol
+++ b/chains/avalanche/AvalancheLib.sol
@@ -128,6 +128,7 @@ library AvalancheLib {
         factory.setStrategyImplementation(StrategyIdLib.AAVE, address(new AaveStrategy()));
         factory.setStrategyImplementation(StrategyIdLib.EULER_MERKL_FARM, address(new EulerMerklFarmStrategy()));
         factory.setStrategyImplementation(StrategyIdLib.SILO_MANAGED_MERKL_FARM, address(new SiloManagedMerklFarmStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.SILO_MERKL_FARM, address(new SiloMerklFarmStrategy()));
         //endregion
 
         //region ----- Add DeX aggregators -----

--- a/chains/avalanche/AvalancheLib.sol
+++ b/chains/avalanche/AvalancheLib.sol
@@ -211,17 +211,7 @@ library AvalancheLib {
     }
 
     function _addStrategyLogic(IFactory factory, string memory id, address implementation, bool farming) internal {
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: id,
-                implementation: address(implementation),
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: farming,
-                tokenId: type(uint).max
-            }),
-            StrategyDeveloperLib.getDeveloper(id)
-        );
+        factory.setStrategyImplementation(id, address(implementation));
     }
 
     function testChainDeployLib() external {}

--- a/chains/sonic/SonicLib.sol
+++ b/chains/sonic/SonicLib.sol
@@ -223,32 +223,27 @@ library SonicLib {
         //endregion -- Add strategy available init params -----
 
         //region ----- Deploy strategy logics -----
-        _addStrategyLogic(factory, StrategyIdLib.BEETS_STABLE_FARM, address(new BeetsStableFarm()), true);
-        _addStrategyLogic(factory, StrategyIdLib.BEETS_WEIGHTED_FARM, address(new BeetsWeightedFarm()), true);
-        _addStrategyLogic(factory, StrategyIdLib.EQUALIZER_FARM, address(new EqualizerFarmStrategy()), true);
-        _addStrategyLogic(factory, StrategyIdLib.ICHI_SWAPX_FARM, address(new IchiSwapXFarmStrategy()), true);
-        _addStrategyLogic(factory, StrategyIdLib.SWAPX_FARM, address(new SwapXFarmStrategy()), true);
-        _addStrategyLogic(
-            factory, StrategyIdLib.GAMMA_UNISWAPV3_MERKL_FARM, address(new GammaUniswapV3MerklFarmStrategy()), true
-        );
-        _addStrategyLogic(factory, StrategyIdLib.SILO_FARM, address(new SiloFarmStrategy()), true);
-        _addStrategyLogic(factory, StrategyIdLib.ALM_SHADOW_FARM, address(new ALMShadowFarmStrategy()), true);
-        _addStrategyLogic(factory, StrategyIdLib.SILO_LEVERAGE, address(new SiloLeverageStrategy()), false);
-        _addStrategyLogic(
-            factory, StrategyIdLib.SILO_ADVANCED_LEVERAGE, address(new SiloAdvancedLeverageStrategy()), false
-        );
-        _addStrategyLogic(factory, StrategyIdLib.GAMMA_EQUALIZER_FARM, address(new GammaEqualizerFarmStrategy()), true);
-        _addStrategyLogic(factory, StrategyIdLib.ICHI_EQUALIZER_FARM, address(new IchiEqualizerFarmStrategy()), true);
-        _addStrategyLogic(factory, StrategyIdLib.EULER_MERKL_FARM, address(new EulerMerklFarmStrategy()), true);
-        _addStrategyLogic(factory, StrategyIdLib.SILO, address(new SiloStrategy()), false);
-        _addStrategyLogic(factory, StrategyIdLib.EULER, address(new EulerStrategy()), false);
-        _addStrategyLogic(factory, StrategyIdLib.AAVE, address(new AaveStrategy()), false);
-        _addStrategyLogic(factory, StrategyIdLib.SILO_MANAGED_FARM, address(new SiloManagedFarmStrategy()), true);
-        _addStrategyLogic(factory, StrategyIdLib.SILO_ALMF_FARM, address(new SiloALMFStrategy()), true);
-        _addStrategyLogic(factory, StrategyIdLib.AAVE_MERKL_FARM, address(new AaveMerklFarmStrategy()), true);
-        _addStrategyLogic(factory, StrategyIdLib.COMPOUND_V2, address(new CompoundV2Strategy()), false);
-        _addStrategyLogic(factory, StrategyIdLib.SILO_MANAGED_MERKL_FARM, address(new SiloManagedMerklFarmStrategy()), true);
-        _addStrategyLogic(factory, StrategyIdLib.SILO_MERKL_FARM, address(new SiloMerklFarmStrategy()), true);
+        factory.setStrategyImplementation(StrategyIdLib.BEETS_STABLE_FARM, address(new BeetsStableFarm()));
+        factory.setStrategyImplementation(StrategyIdLib.BEETS_WEIGHTED_FARM, address(new BeetsWeightedFarm()));
+        factory.setStrategyImplementation(StrategyIdLib.EQUALIZER_FARM, address(new EqualizerFarmStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.ICHI_SWAPX_FARM, address(new IchiSwapXFarmStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.SWAPX_FARM, address(new SwapXFarmStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.GAMMA_UNISWAPV3_MERKL_FARM, address(new GammaUniswapV3MerklFarmStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.SILO_FARM, address(new SiloFarmStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.ALM_SHADOW_FARM, address(new ALMShadowFarmStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.SILO_LEVERAGE, address(new SiloLeverageStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.SILO_ADVANCED_LEVERAGE, address(new SiloAdvancedLeverageStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.GAMMA_EQUALIZER_FARM, address(new GammaEqualizerFarmStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.ICHI_EQUALIZER_FARM, address(new IchiEqualizerFarmStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.EULER_MERKL_FARM, address(new EulerMerklFarmStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.SILO, address(new SiloStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.EULER, address(new EulerStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.AAVE, address(new AaveStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.SILO_MANAGED_FARM, address(new SiloManagedFarmStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.SILO_ALMF_FARM, address(new SiloALMFStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.AAVE_MERKL_FARM, address(new AaveMerklFarmStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.COMPOUND_V2, address(new CompoundV2Strategy()));
+        factory.setStrategyImplementation(StrategyIdLib.SILO_MANAGED_MERKL_FARM, address(new SiloManagedMerklFarmStrategy()));
         LogDeployLib.logDeployStrategies(platform, showLog);
         //endregion
 
@@ -464,10 +459,6 @@ library SonicLib {
         address tokenOut
     ) internal pure returns (ISwapper.AddPoolData memory) {
         return ISwapper.AddPoolData({pool: pool, ammAdapterId: ammAdapterId, tokenIn: tokenIn, tokenOut: tokenOut});
-    }
-
-    function _addStrategyLogic(IFactory factory, string memory id, address implementation, bool farming) internal {
-        factory.setStrategyImplementation(id, address(implementation));
     }
 
     function testChainLib() external {}

--- a/chains/sonic/SonicLib.sol
+++ b/chains/sonic/SonicLib.sol
@@ -244,6 +244,7 @@ library SonicLib {
         factory.setStrategyImplementation(StrategyIdLib.AAVE_MERKL_FARM, address(new AaveMerklFarmStrategy()));
         factory.setStrategyImplementation(StrategyIdLib.COMPOUND_V2, address(new CompoundV2Strategy()));
         factory.setStrategyImplementation(StrategyIdLib.SILO_MANAGED_MERKL_FARM, address(new SiloManagedMerklFarmStrategy()));
+        factory.setStrategyImplementation(StrategyIdLib.SILO_MERKL_FARM, address(new SiloMerklFarmStrategy()));
         LogDeployLib.logDeployStrategies(platform, showLog);
         //endregion
 

--- a/chains/sonic/SonicLib.sol
+++ b/chains/sonic/SonicLib.sol
@@ -467,17 +467,7 @@ library SonicLib {
     }
 
     function _addStrategyLogic(IFactory factory, string memory id, address implementation, bool farming) internal {
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: id,
-                implementation: address(implementation),
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: farming,
-                tokenId: type(uint).max
-            }),
-            StrategyDeveloperLib.getDeveloper(id)
-        );
+        factory.setStrategyImplementation(id, address(implementation));
     }
 
     function testChainLib() external {}

--- a/guides/ADM.md
+++ b/guides/ADM.md
@@ -132,17 +132,19 @@ struct StrategyLogicConfig {
     uint tokenId;
 }
 
-/// @notice Initial addition or change of strategy logic settings.
+/// @notice Initial addition or change of strategy logic implementation.
 /// Operator can add new strategy logic. Governance or multisig can change existing logic config.
-/// @param config Strategy logic settings
-/// @param developer Strategy developer is receiver of minted StrategyLogic NFT on initial addition
-function setStrategyLogicConfig(StrategyLogicConfig memory config, address developer) external;
+/// @param strategyId Strategy logic ID string
+/// @param implementation Address of strategy implementation
+function setStrategyImplementation(string memory strategyId, address implementation) external;
 ```
 </details>
 
+<!-- TODO: `8. setStrategyImplementation` is the number really 8 ??  -->
+
 * [Factory sonicscan](https://sonicscan.org/address/0xc184a3ecca684f2621c903a7943d85fa42f56671#writeProxyContract)
 * Connect operator wallet
-* `8. setStrategyLogicConfig`
+* `8. setStrategyImplementation`
 * fill
 
 ## Multisig actions
@@ -185,7 +187,9 @@ Call it via Safe Transaction Builder:
 
 ### Set vault config
 
-Use `IFactory.setVaultConfig` method.
+<!-- TODO  -->
+
+Use `IFactory.setVaultImplementation` method.
 
 View current building prices and vault type string IDs on [Factory](https://sonicscan.org/address/0xc184a3ecca684f2621c903a7943d85fa42f56671#readProxyContract) `24. vaultTypes`
 
@@ -201,10 +205,11 @@ struct VaultConfig {
     uint buildingPrice;
 }
 
-/// @notice Initial addition or change of vault type settings.
+/// @notice Initial addition or change of vault type implementation.
 /// Operator can add new vault type. Governance or multisig can change existing vault type config.
-/// @param vaultConfig_ Vault type settings
-function setVaultConfig(VaultConfig memory vaultConfig_) external;
+/// @param vaultType Vault type string ID (Compounding, etc)
+/// @param implementation Address of implementation
+function setVaultImplementation(string memory vaultType, address implementation) external;
 ```
 </details>
 
@@ -217,8 +222,10 @@ Call it via Safe Transaction Builder:
 <details>
   <summary>ABI</summary>
 
+<!-- TODO: Change ABI -->
+
 `
-[{"inputs": [{"components": [{"internalType": "string","name": "vaultType","type": "string"},{"internalType": "address","name": "implementation","type": "address"},{"internalType": "bool","name": "deployAllowed","type": "bool"},{"internalType": "bool","name": "upgradeAllowed","type": "bool"},{"internalType": "uint256","name":"buildingPrice","type": "uint256"}],"internalType": "struct IFactory.VaultConfig","name": "vaultConfig_","type": "tuple"}],"name": "setVaultConfig","outputs": [],"stateMutability": "nonpayable","type": "function"}]
+[{"inputs":[{"internalType":"string","name":"vaultType","type":"string"},{"internalType":"address","name":"implementation","type":"address"}],"name":"setVaultImplementation","outputs":[],"stateMutability":"nonpayable","type":"function"}]
 `
 </details>
 
@@ -228,7 +235,7 @@ Call it via Safe Transaction Builder:
 
 ### Upgrade strategy
 
-Use `IFactory.setStrategyLogicConfig` method.
+Use `IFactory.setStrategyImplementation` method.
 This need to add new strategy, upgrade strategy implementation or disable vaults building.
 
 <details>
@@ -244,11 +251,11 @@ struct StrategyLogicConfig {
     uint tokenId;
 }
 
-/// @notice Initial addition or change of strategy logic settings.
+/// @notice Initial addition or change of strategy logic implementation.
 /// Operator can add new strategy logic. Governance or multisig can change existing logic config.
-/// @param config Strategy logic settings
-/// @param developer Strategy developer is receiver of minted StrategyLogic NFT on initial addition
-function setStrategyLogicConfig(StrategyLogicConfig memory config, address developer) external;
+/// @param strategyId Strategy logic ID string
+/// @param implementation Address of strategy implementation
+function setStrategyImplementation(string memory strategyId, address implementation) external;
 ```
 </details>
 
@@ -261,8 +268,10 @@ Call it via Safe Transaction Builder:
 <details>
   <summary>ABI</summary>
 
+  <!-- TODO: Change ABI -->
+
 `
-[{"type": "function","name": "strategyLogicConfig","inputs": [{"name": "idHash","type": "bytes32","internalType": "bytes32"}],"outputs": [{"name": "config","type": "tuple","internalType": "struct IFactory.StrategyLogicConfig","components": [{"name": "id","type": "string","internalType": "string"},{"name": "implementation","type": "address","internalType": "address"},{"name": "deployAllowed","type": "bool","internalType": "bool"},{"name": "upgradeAllowed","type": "bool","internalType": "bool"},{"name": "farming","type": "bool","internalType": "bool"},{"name": "tokenId","type": "uint256","internalType": "uint256"}]}],"stateMutability": "view"},{"type": "function","name": "setStrategyLogicConfig","inputs": [{"name": "config","type": "tuple","internalType": "struct IFactory.StrategyLogicConfig","components": [{"name": "id","type": "string","internalType": "string"},{"name": "implementation","type": "address","internalType": "address"},{"name": "deployAllowed","type": "bool","internalType": "bool"},{"name": "upgradeAllowed","type": "bool","internalType": "bool"},{"name": "farming","type": "bool","internalType": "bool"},{"name": "tokenId","type": "uint256","internalType": "uint256"}]},{"name": "developer","type": "address","internalType": "address"}],"outputs": [],"stateMutability": "nonpayable"}]
+[{"inputs":[{"internalType":"string","name":"strategyId","type":"string"},{"internalType":"address","name":"implementation","type":"address"}],"name":"setStrategyImplementation","outputs":[],"stateMutability":"nonpayable","type":"function"}]
 `
 </details>
 

--- a/src/core/Factory.sol
+++ b/src/core/Factory.sol
@@ -31,10 +31,7 @@ import {IStrategyLogic} from "../interfaces/IStrategyLogic.sol";
 ///          - Governance/Operator config is now managed via `setVaultImplementation`
 ///            and `setStrategyImplementation`
 ///          * Integrations and deployment scripts must be updated accordingly
-<<<<<<< HEAD
 ///   1.3.1: setStrategyImplementation added to interface
-=======
->>>>>>> 54414f17e9d307c33701982d16689e8b6612623b
 ///   1.3.0: vault can be built only by admin; setVaultImplementation, setStrategyImplementation;
 ///          remove setAliasName, getAliasName, whatToBuild; remove RVault and RMVault support
 ///   1.2.0: reduced factory size. moved upgradeStrategyProxy, upgradeVaultProxy logic to FactoryLib

--- a/src/core/Factory.sol
+++ b/src/core/Factory.sol
@@ -24,6 +24,13 @@ import {IStrategyLogic} from "../interfaces/IStrategyLogic.sol";
 /// @notice Platform factory assembling vaults. Stores vault settings, strategy logic, farms.
 ///         Provides the opportunity to upgrade vaults and strategies.
 /// Changelog:
+///   2.0.0: BREAKING CHANGES
+///          * Removed `setVaultConfig` from IFactory
+///          * Removed `setStrategyLogicConfig` from IFactory
+///          - These functions are no longer available in the ABI
+///          - Governance/Operator config is now managed via `setVaultImplementation`
+///            and `setStrategyImplementation`
+///          * Integrations and deployment scripts must be updated accordingly
 ///   1.3.1: setStrategyImplementation added to interface
 ///   1.3.0: vault can be built only by admin; setVaultImplementation, setStrategyImplementation;
 ///          remove setAliasName, getAliasName, whatToBuild; remove RVault and RMVault support
@@ -40,7 +47,7 @@ contract Factory is Controllable, ReentrancyGuardUpgradeable, IFactory {
     //region ----- Constants -----
 
     /// @inheritdoc IControllable
-    string public constant VERSION = "1.3.1";
+    string public constant VERSION = "2.0.0";
 
     uint internal constant _WEEK = 60 * 60 * 24 * 7;
 
@@ -81,26 +88,9 @@ contract Factory is Controllable, ReentrancyGuardUpgradeable, IFactory {
     //region ----- Restricted actions -----
 
     /// @inheritdoc IFactory
-    function setVaultConfig(VaultConfig memory vaultConfig_) external onlyOperator {
-        FactoryStorage storage $ = _getStorage();
-        if (FactoryLib.setVaultImplementation($, vaultConfig_.vaultType, vaultConfig_.implementation)) {
-            _requireGovernanceOrMultisig();
-        }
-    }
-
-    /// @inheritdoc IFactory
     function setVaultImplementation(string memory vaultType, address implementation) external onlyOperator {
         FactoryStorage storage $ = _getStorage();
         if (FactoryLib.setVaultImplementation($, vaultType, implementation)) {
-            _requireGovernanceOrMultisig();
-        }
-    }
-
-    /// @inheritdoc IFactory
-    //slither-disable-next-line reentrancy-no-eth
-    function setStrategyLogicConfig(StrategyLogicConfig memory config, address) external onlyOperator {
-        FactoryStorage storage $ = _getStorage();
-        if (FactoryLib.setStrategyImplementation($, platform(), config.id, config.implementation)) {
             _requireGovernanceOrMultisig();
         }
     }

--- a/src/interfaces/IFactory.sol
+++ b/src/interfaces/IFactory.sol
@@ -308,15 +308,6 @@ interface IFactory {
     /// @param implementation Address of vault implementation
     function setVaultImplementation(string memory vaultType, address implementation) external;
 
-<<<<<<< HEAD
-=======
-    /// @notice Initial addition or change of strategy logic implementation.
-    /// Operator can add new strategy logic. Governance or multisig can change existing logic config.
-    /// @param strategyId Strategy logic ID string
-    /// @param implementation Address of strategy implementation
-    function setStrategyImplementation(string memory strategyId, address implementation) external;
-
->>>>>>> 54414f17e9d307c33701982d16689e8b6612623b
     /// @notice Governance and multisig can set a vault status other than Active - the default status.
     /// @param vaults Addresses of vault proxy
     /// @param statuses New vault statuses. Constant from VaultStatusLib

--- a/src/interfaces/IFactory.sol
+++ b/src/interfaces/IFactory.sol
@@ -302,22 +302,11 @@ interface IFactory {
     /// @param farm_ Settings and data required to work with the farm.
     function updateFarm(uint id, Farm memory farm_) external;
 
-    /// @notice Initial addition or change of vault type settings.
-    /// Operator can add new vault type. Governance or multisig can change existing vault type config.
-    /// @param vaultConfig_ Vault type settings
-    function setVaultConfig(VaultConfig memory vaultConfig_) external;
-
     /// @notice Initial addition or change of vault type implementation
     /// Operator can add new vault type. Governance or multisig can change existing vault type config.
     /// @param vaultType Vault type string ID (Compounding, etc)
-    /// @param implementation Address of implementation
+    /// @param implementation Address of vault implementation
     function setVaultImplementation(string memory vaultType, address implementation) external;
-
-    /// @notice Initial addition or change of strategy logic settings.
-    /// Operator can add new strategy logic. Governance or multisig can change existing logic config.
-    /// @param config Strategy logic settings
-    /// @param developer Strategy developer is receiver of minted StrategyLogic NFT on initial addition
-    function setStrategyLogicConfig(StrategyLogicConfig memory config, address developer) external;
 
     /// @notice Governance and multisig can set a vault status other than Active - the default status.
     /// @param vaults Addresses of vault proxy
@@ -330,6 +319,10 @@ interface IFactory {
     function setStrategyAvailableInitParams(string memory id, StrategyAvailableInitParams memory initParams) external;
 
     /// @notice Set new implementation of the strategy
+    /// @dev Initial addition or change of strategy logic implementation.
+    /// Operator can add new strategy logic. Governance or multisig can change existing logic config.
+    /// @param strategyId Strategy logic ID string
+    /// @param implementation Address of strategy implementation
     function setStrategyImplementation(string memory strategyId, address implementation) external;
 
     //endregion -- Write functions -----

--- a/src/strategies/DefiEdgeQuickSwapMerklFarmStrategy.sol
+++ b/src/strategies/DefiEdgeQuickSwapMerklFarmStrategy.sol
@@ -20,7 +20,6 @@ import {FarmMechanicsLib} from "./libs/FarmMechanicsLib.sol";
 import {ALMPositionNameLib} from "./libs/ALMPositionNameLib.sol";
 import {AmmAdapterIdLib} from "../adapters/libs/AmmAdapterIdLib.sol";
 import {ICAmmAdapter} from "../interfaces/ICAmmAdapter.sol";
-import {IAmmAdapter} from "../interfaces/IAmmAdapter.sol";
 import {IDefiEdgeStrategy} from "../integrations/defiedge/IDefiEdgeStrategy.sol";
 import {IDefiEdgeStrategyFactory} from "../integrations/defiedge/IDefiEdgeStrategyFactory.sol";
 import {IFeedRegistryInterface} from "../integrations/chainlink/IFeedRegistryInterface.sol";

--- a/src/strategies/IchiRetroMerklFarmStrategy.sol
+++ b/src/strategies/IchiRetroMerklFarmStrategy.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.28;
 
 import {SafeERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
-import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import {LPStrategyBase, ILPStrategy, IERC165, StrategyBase, LPStrategyLib} from "./base/LPStrategyBase.sol";
 import {MerklStrategyBase} from "./base/MerklStrategyBase.sol";
 import {FarmingStrategyBase, IFarmingStrategy, IFactory, IPlatform, StrategyLib} from "./base/FarmingStrategyBase.sol";

--- a/src/strategies/IchiSwapXFarmStrategy.sol
+++ b/src/strategies/IchiSwapXFarmStrategy.sol
@@ -3,8 +3,6 @@ pragma solidity ^0.8.28;
 
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {SafeERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
-import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {LPStrategyBase, StrategyBase, IERC165, ILPStrategy} from "./base/LPStrategyBase.sol";
 import {FarmingStrategyBase, StrategyLib, IPlatform, IFarmingStrategy, IFactory} from "./base/FarmingStrategyBase.sol";
 import {IStrategy} from "../interfaces/IStrategy.sol";
@@ -19,7 +17,6 @@ import {AmmAdapterIdLib} from "../adapters/libs/AmmAdapterIdLib.sol";
 import {IICHIVaultV4} from "../integrations/ichi/IICHIVaultV4.sol";
 import {IGaugeV2_CL} from "../integrations/swapx/IGaugeV2_CL.sol";
 import {IVoterV3} from "../integrations/swapx/IVoterV3.sol";
-import {IAlgebraPool} from "../integrations/algebrav4/IAlgebraPool.sol";
 
 /// @title Earn SwapX farm rewards by Ichi ALM
 /// Changelog

--- a/src/strategies/SiloMerklFarmStrategy.sol
+++ b/src/strategies/SiloMerklFarmStrategy.sol
@@ -169,7 +169,7 @@ contract SiloMerklFarmStrategy is MerklStrategyBase, FarmingStrategyBase {
 
         // get price of 1 amount of asset in USD with decimals 18
         // assume that {trusted} value doesn't matter here
-        /// slither-disable-next-line unused-return
+        // slither-disable-next-line unused-return
         (uint price,) = priceReader.getPrice(asset);
 
         return siloVault.totalAssets() * price / (10 ** IERC20Metadata(asset).decimals());

--- a/src/strategies/SiloMerklFarmStrategy.sol
+++ b/src/strategies/SiloMerklFarmStrategy.sol
@@ -88,6 +88,7 @@ contract SiloMerklFarmStrategy is MerklStrategyBase, FarmingStrategyBase {
 
     /// @inheritdoc IStrategy
     function extra() external pure returns (bytes32) {
+        // slither-disable-next-line too-many-digits
         return CommonLib.bytesToBytes32(abi.encodePacked(bytes3(0x00d395), bytes3(0x000000)));
     }
 
@@ -135,7 +136,7 @@ contract SiloMerklFarmStrategy is MerklStrategyBase, FarmingStrategyBase {
         view
         returns (string[] memory variants, address[] memory addresses, uint[] memory nums, int24[] memory ticks)
     {
-        /// slither-disable-next-line ignore-unused-return
+        // slither-disable-next-line unused-return
         return SharedLib.initVariantsForFarm(platform_, STRATEGY_LOGIC_ID, _genDesc);
     }
 
@@ -168,7 +169,7 @@ contract SiloMerklFarmStrategy is MerklStrategyBase, FarmingStrategyBase {
 
         // get price of 1 amount of asset in USD with decimals 18
         // assume that {trusted} value doesn't matter here
-        /// slither-disable-next-line ignore-unused-return
+        /// slither-disable-next-line unused-return
         (uint price,) = priceReader.getPrice(asset);
 
         return siloVault.totalAssets() * price / (10 ** IERC20Metadata(asset).decimals());
@@ -239,6 +240,7 @@ contract SiloMerklFarmStrategy is MerklStrategyBase, FarmingStrategyBase {
         if (address(this) == receiver) {
             toWithdraw--;
         }
+        // slither-disable-next-line reentrancy-benign
         siloVault.withdraw(toWithdraw, receiver, address(this), ISilo.CollateralType.Collateral);
         amountsOut = new uint[](1);
         amountsOut[0] = value;
@@ -298,6 +300,7 @@ contract SiloMerklFarmStrategy is MerklStrategyBase, FarmingStrategyBase {
                 uint amountXSilo = StrategyLib.balance(xSilo);
                 if (amountXSilo != 0) {
                     // instant exit with penalty 50%
+                    // slither-disable-next-line calls-loop
                     __rewardAmounts[i] += IXSilo(xSilo).redeemSilo(amountXSilo, 0);
                 }
             }

--- a/src/strategies/libs/SiloAdvancedLib.sol
+++ b/src/strategies/libs/SiloAdvancedLib.sol
@@ -22,7 +22,6 @@ import {LeverageLendingLib} from "./LeverageLendingLib.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {StrategyLib} from "./StrategyLib.sol";
-import {console} from "forge-std/console.sol";
 
 library SiloAdvancedLib {
     using SafeERC20 for IERC20;

--- a/src/strategies/libs/StrategyLib.sol
+++ b/src/strategies/libs/StrategyLib.sol
@@ -67,7 +67,7 @@ library StrategyLib {
         // nosemgrep
         for (uint i; i < len; ++i) {
             amountsOut[i] = balance(assets[i]) * amount / total_;
-            IERC20(assets[i]).transfer(receiver, amountsOut[i]);
+            IERC20(assets[i]).safeTransfer(receiver, amountsOut[i]);
         }
     }
 

--- a/src/tokenomics/TokenSender.sol
+++ b/src/tokenomics/TokenSender.sol
@@ -15,9 +15,12 @@ contract TokenSender {
     function send(address token, address[] calldata receivers, uint[] calldata amounts) external {
         require(IPlatform(platform).isOperator(msg.sender), "denied");
         uint len = receivers.length;
+        /// @dev it is a deployed non-upgradeable contract, we can only disable warnings instead of using `safeTransferFrom`
+        /// forge-lint: disable-start(erc20-unchecked-transfer)
         for (uint i; i < len; ++i) {
             // slither-disable-next-line unchecked-transfer
             IERC20(token).transferFrom(msg.sender, receivers[i], amounts[i]);
         }
+        /// forge-lint: disable-end(erc20-unchecked-transfer)
     }
 }

--- a/src/tokenomics/XSTBL.sol
+++ b/src/tokenomics/XSTBL.sol
@@ -9,19 +9,24 @@ import {IControllable} from "../interfaces/IControllable.sol";
 import {IXSTBL} from "../interfaces/IXSTBL.sol";
 import {IXStaking} from "../interfaces/IXStaking.sol";
 import {IRevenueRouter} from "../interfaces/IRevenueRouter.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 /// @title xSTBL token
 /// Inspired by xRAM/xSHADOW from Ramses/Shadow codebase
 /// @author Alien Deployer (https://github.com/a17)
+/// @author Jude (https://github.com/iammrjude)
+/// Changelog:
+///  1.0.1: use SafeERC20.safeTransfer/safeTransferFrom instead of ERC20 transfer/transferFrom
 contract XSTBL is Controllable, ERC20Upgradeable, IXSTBL {
     using EnumerableSet for EnumerableSet.AddressSet;
+    using SafeERC20 for IERC20;
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                         CONSTANTS                          */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     /// @inheritdoc IControllable
-    string public constant VERSION = "1.0.0";
+    string public constant VERSION = "1.0.1";
 
     /// @inheritdoc IXSTBL
     uint public constant BASIS = 10_000;
@@ -169,7 +174,7 @@ contract XSTBL is Controllable, ERC20Upgradeable, IXSTBL {
         require(amount_ != 0, IncorrectZeroArgument());
         /// @dev transfer from the caller to this address
         // slither-disable-next-line unchecked-transfer
-        IERC20(STBL()).transferFrom(msg.sender, address(this), amount_);
+        IERC20(STBL()).safeTransferFrom(msg.sender, address(this), amount_);
         /// @dev mint the xSTBL to the caller
         _mint(msg.sender, amount_);
         /// @dev emit an event for conversion
@@ -195,7 +200,7 @@ contract XSTBL is Controllable, ERC20Upgradeable, IXSTBL {
 
         /// @dev transfer the exitAmount to the caller
         // slither-disable-next-line unchecked-transfer
-        IERC20($.STBL).transfer(msg.sender, exitAmount);
+        IERC20($.STBL).safeTransfer(msg.sender, exitAmount);
 
         /// @dev emit actual exited amount
         emit InstantExit(msg.sender, exitAmount);
@@ -246,7 +251,7 @@ contract XSTBL is Controllable, ERC20Upgradeable, IXSTBL {
             /// @dev case: vest is complete
             /// @dev send liquid STBL to msg.sender
             // slither-disable-next-line unchecked-transfer
-            IERC20($.STBL).transfer(msg.sender, _amount);
+            IERC20($.STBL).safeTransfer(msg.sender, _amount);
 
             emit ExitVesting(msg.sender, vestID_, _amount, _amount);
         } else {
@@ -267,7 +272,7 @@ contract XSTBL is Controllable, ERC20Upgradeable, IXSTBL {
 
             /// @dev transfer underlying to the sender after penalties removed
             // slither-disable-next-line unchecked-transfer
-            IERC20($.STBL).transfer(msg.sender, exitedAmount);
+            IERC20($.STBL).safeTransfer(msg.sender, exitedAmount);
 
             emit ExitVesting(msg.sender, vestID_, _amount, exitedAmount);
         }

--- a/src/tokenomics/XStaking.sol
+++ b/src/tokenomics/XStaking.sol
@@ -8,17 +8,23 @@ import {Controllable} from "../core/base/Controllable.sol";
 import {IControllable} from "../interfaces/IControllable.sol";
 import {IXStaking} from "../interfaces/IXStaking.sol";
 import {IXSTBL} from "../interfaces/IXSTBL.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 /// @title Staking contract for xSTBL
 /// Inspired by VoteModule from Ramses/Shadow codebase
 /// @author Alien Deployer (https://github.com/a17)
+/// @author Jude (https://github.com/iammrjude)
+/// Changelog:
+///  1.0.1: use SafeERC20.safeTransfer/safeTransferFrom instead of ERC20 transfer/transferFrom
 contract XStaking is Controllable, ReentrancyGuardUpgradeable, IXStaking {
+    using SafeERC20 for IERC20;
+
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                         CONSTANTS                          */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     /// @inheritdoc IControllable
-    string public constant VERSION = "1.0.0";
+    string public constant VERSION = "1.0.1";
 
     /// @notice decimal precision of 1e18
     uint public constant PRECISION = 10 ** 18;
@@ -107,7 +113,7 @@ contract XStaking is Controllable, ReentrancyGuardUpgradeable, IXStaking {
 
         /// @dev transfer xSTBL in
         // slither-disable-next-line unchecked-transfer
-        IERC20($.xSTBL).transferFrom(msg.sender, address(this), amount);
+        IERC20($.xSTBL).safeTransferFrom(msg.sender, address(this), amount);
 
         /// @dev update accounting
         $.totalSupply += amount;
@@ -146,7 +152,7 @@ contract XStaking is Controllable, ReentrancyGuardUpgradeable, IXStaking {
 
         /// @dev transfer the xSTBL to the caller
         // slither-disable-next-line unchecked-transfer
-        IERC20($.xSTBL).transfer(msg.sender, amount);
+        IERC20($.xSTBL).safeTransfer(msg.sender, amount);
 
         emit Withdraw(msg.sender, amount);
     }
@@ -165,7 +171,7 @@ contract XStaking is Controllable, ReentrancyGuardUpgradeable, IXStaking {
 
         /// @dev take the STBL from a contract to the XStaking
         // slither-disable-next-line unchecked-transfer
-        IERC20(IXSTBL(_xSTBL).STBL()).transferFrom(msg.sender, address(this), amount);
+        IERC20(IXSTBL(_xSTBL).STBL()).safeTransferFrom(msg.sender, address(this), amount);
 
         uint _periodFinish = $.periodFinish;
         uint _duration = $.duration;
@@ -325,7 +331,7 @@ contract XStaking is Controllable, ReentrancyGuardUpgradeable, IXStaking {
 
             /// @dev transfer xSTBL to the user
             // slither-disable-next-line unchecked-transfer
-            IERC20(_xSTBL).transfer(user, reward);
+            IERC20(_xSTBL).safeTransfer(user, reward);
 
             emit ClaimRewards(user, reward);
         }

--- a/test/base/FullMockSetup.sol
+++ b/test/base/FullMockSetup.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.28;
 import {IPlatform} from "../../src/core/Platform.sol";
 import {PriceReader} from "../../src/core/PriceReader.sol";
 import {Proxy} from "../../src/core/proxy/Proxy.sol";
-import {Factory, IFactory} from "../../src/core/Factory.sol";
+import {Factory} from "../../src/core/Factory.sol";
 import {MockAggregatorV3Interface} from "../../src/test/MockAggregatorV3Interface.sol";
 import {ChainlinkAdapter} from "../../src/adapters/ChainlinkAdapter.sol";
 import {MockStrategy} from "../../src/test/MockStrategy.sol";

--- a/test/base/FullMockSetup.sol
+++ b/test/base/FullMockSetup.sol
@@ -105,17 +105,7 @@ abstract contract FullMockSetup is MockSetup {
         // setup factory
         factory.setVaultImplementation(VaultTypeLib.COMPOUNDING, address(vaultImplementation));
         MockStrategy strategyImplementation = new MockStrategy();
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.DEV,
-                implementation: address(strategyImplementation),
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: false,
-                tokenId: type(uint).max
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.DEV, address(strategyImplementation));
     }
 
     function testFullMockSetup() public {}

--- a/test/base/chains/AvalancheSetup.sol
+++ b/test/base/chains/AvalancheSetup.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.23;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {AvalancheLib} from "../../../chains/avalanche/AvalancheLib.sol";
 import {AvalancheConstantsLib} from "../../../chains/avalanche/AvalancheConstantsLib.sol";
 import {ChainSetup} from "../ChainSetup.sol";
@@ -12,6 +13,8 @@ import {ISwapper} from "../../../src/interfaces/ISwapper.sol";
 import {IPlatform} from "../../../src/interfaces/IPlatform.sol";
 
 abstract contract AvalancheSetup is ChainSetup, DeployCore {
+    using SafeERC20 for IERC20;
+
     bool public showDeployLog;
 
     constructor() {
@@ -44,7 +47,7 @@ abstract contract AvalancheSetup is ChainSetup, DeployCore {
             swapper.swap(AvalancheConstantsLib.TOKEN_USDC, AvalancheConstantsLib.TOKEN_AUSD, 2 * amount, 1_000); // 1%
 
             vm.prank(user);
-            IERC20(AvalancheConstantsLib.TOKEN_AUSD).transfer(to, amount);
+            IERC20(AvalancheConstantsLib.TOKEN_AUSD).safeTransfer(to, amount);
         } else {
             deal(token, to, amount);
         }

--- a/test/batch/libs/CVaultBatchLib.sol
+++ b/test/batch/libs/CVaultBatchLib.sol
@@ -551,17 +551,7 @@ library CVaultBatchLib {
         address strategyImplementation = address(new SiloALMFStrategy());
 
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO_ALMF_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO_ALMF_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -570,17 +560,7 @@ library CVaultBatchLib {
         address strategyImplementation = address(new SiloManagedMerklFarmStrategy());
 
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO_MANAGED_MERKL_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO_MANAGED_MERKL_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }

--- a/test/batch/libs/CVaultBatchLib.sol
+++ b/test/batch/libs/CVaultBatchLib.sol
@@ -384,17 +384,7 @@ library CVaultBatchLib {
         address strategyImplementation = address(new SiloStrategy());
 
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: false,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -402,17 +392,7 @@ library CVaultBatchLib {
     function _upgradeSiloFarmStrategy(Vm vm, address multisig, IFactory factory, address strategyAddress) internal {
         address strategyImplementation = address(new SiloFarmStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -426,17 +406,7 @@ library CVaultBatchLib {
         address strategyImplementation = address(new SiloManagedFarmStrategy());
 
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO_MANAGED_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO_MANAGED_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -450,17 +420,7 @@ library CVaultBatchLib {
         address strategyImplementation = address(new IchiSwapXFarmStrategy());
 
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.ICHI_SWAPX_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.ICHI_SWAPX_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -469,17 +429,7 @@ library CVaultBatchLib {
         address strategyImplementation = address(new SiloAdvancedLeverageStrategy());
 
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO_ADVANCED_LEVERAGE,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: false,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO_ADVANCED_LEVERAGE, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -488,17 +438,7 @@ library CVaultBatchLib {
         address strategyImplementation = address(new BeetsStableFarm());
 
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.BEETS_STABLE_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.BEETS_STABLE_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -507,17 +447,7 @@ library CVaultBatchLib {
         address strategyImplementation = address(new BeetsWeightedFarm());
 
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.BEETS_WEIGHTED_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.BEETS_WEIGHTED_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -526,17 +456,7 @@ library CVaultBatchLib {
         address strategyImplementation = address(new EqualizerFarmStrategy());
 
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.EQUALIZER_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.EQUALIZER_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -545,17 +465,7 @@ library CVaultBatchLib {
         address strategyImplementation = address(new SwapXFarmStrategy());
 
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SWAPX_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SWAPX_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -569,17 +479,7 @@ library CVaultBatchLib {
         address strategyImplementation = address(new GammaUniswapV3MerklFarmStrategy());
 
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.GAMMA_UNISWAPV3_MERKL_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.GAMMA_UNISWAPV3_MERKL_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -588,17 +488,7 @@ library CVaultBatchLib {
         address strategyImplementation = address(new ALMShadowFarmStrategy());
 
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.ALM_SHADOW_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.ALM_SHADOW_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -607,17 +497,7 @@ library CVaultBatchLib {
         address strategyImplementation = address(new SiloLeverageStrategy());
 
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO_LEVERAGE,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: false,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO_LEVERAGE, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -626,17 +506,7 @@ library CVaultBatchLib {
         address strategyImplementation = address(new AaveStrategy());
 
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.AAVE,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: false,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.AAVE, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -645,17 +515,7 @@ library CVaultBatchLib {
         address strategyImplementation = address(new AaveMerklFarmStrategy());
 
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.AAVE_MERKL_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.AAVE_MERKL_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -664,17 +524,7 @@ library CVaultBatchLib {
         address strategyImplementation = address(new CompoundV2Strategy());
 
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.COMPOUND_V2,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: false,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.COMPOUND_V2, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -683,17 +533,7 @@ library CVaultBatchLib {
         address strategyImplementation = address(new EulerStrategy());
 
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.EULER,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: false,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.EULER, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -702,17 +542,7 @@ library CVaultBatchLib {
         address strategyImplementation = address(new EulerMerklFarmStrategy());
 
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.EULER_MERKL_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: false,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO_ALMF_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }

--- a/test/core/CVault.Upgrade2.Sonic.t.sol
+++ b/test/core/CVault.Upgrade2.Sonic.t.sol
@@ -65,15 +65,7 @@ contract CVaultUpgrade2SonicTest is Test {
         // deploy new impl and upgrade
         address vaultImplementation = address(new CVault());
         vm.prank(multisig);
-        factory.setVaultConfig(
-            IFactory.VaultConfig({
-                vaultType: VaultTypeLib.COMPOUNDING,
-                implementation: vaultImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                buildingPrice: 1e10
-            })
-        );
+        factory.setVaultImplementation(VaultTypeLib.COMPOUNDING, vaultImplementation);
         factory.upgradeVaultProxy(address(vault));
     }
 
@@ -81,17 +73,7 @@ contract CVaultUpgrade2SonicTest is Test {
         // deploy new impl and upgrade
         address strategyImplementation = address(new SiloFarmStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: false,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategy);
     }

--- a/test/core/CVault.UpgradeAudit.Sonic.t.sol
+++ b/test/core/CVault.UpgradeAudit.Sonic.t.sol
@@ -144,17 +144,7 @@ contract CVaultUpgradeAuditSonicTest is Test {
         // deploy new impl and upgrade
         address strategyImplementation = address(new SiloStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: false,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategy);
     }

--- a/test/core/Factory.t.sol
+++ b/test/core/Factory.t.sol
@@ -95,32 +95,12 @@ contract FactoryTest is Test, MockSetup {
             VaultTypeLib.COMPOUNDING, StrategyIdLib.DEV, new address[](0), new uint[](0), addresses, nums, ticks
         );
 
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.DEV,
-                implementation: address(strategyImplementation),
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: false,
-                tokenId: type(uint).max
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.DEV, address(strategyImplementation));
 
         assertEq(platform.isOperator(address(101)), true);
         vm.startPrank(address(101));
         vm.expectRevert(IControllable.NotGovernanceAndNotMultisig.selector);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.DEV,
-                implementation: address(strategyImplementation),
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: false,
-                tokenId: type(uint).max
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.DEV, address(strategyImplementation));
         vm.stopPrank();
 
         uint strategyLogicTokenId = factory.strategyLogicConfig(keccak256(bytes(StrategyIdLib.DEV))).tokenId;
@@ -128,27 +108,9 @@ contract FactoryTest is Test, MockSetup {
         assertEq(hashes.length, 1);
         assertEq(strategyLogic.ownerOf(strategyLogicTokenId), address(this));
 
-        factory.setVaultConfig(
-            IFactory.VaultConfig({
-                vaultType: "TestVaultType",
-                implementation: address(vaultImplementation),
-                deployAllowed: true,
-                upgradeAllowed: true,
-                buildingPrice: 100
-            })
-        );
+        factory.setVaultImplementation("TestVaultType", address(vaultImplementation));
 
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.DEV,
-                implementation: address(strategyImplementation),
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: false,
-                tokenId: type(uint).max
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.DEV, address(strategyImplementation));
 
         vm.expectRevert(bytes("Strategy: underlying token cant be zero for this strategy"));
         factory.deployVaultAndStrategy(
@@ -219,17 +181,7 @@ contract FactoryTest is Test, MockSetup {
 
         factory.setVaultImplementation(VaultTypeLib.COMPOUNDING, address(vaultImplementation));
 
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.DEV,
-                implementation: address(strategyImplementation),
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: false,
-                tokenId: type(uint).max
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.DEV, address(strategyImplementation));
 
         (address vault,) = factory.deployVaultAndStrategy(
             VaultTypeLib.COMPOUNDING, StrategyIdLib.DEV, new address[](0), new uint[](0), addresses, nums, ticks
@@ -266,27 +218,9 @@ contract FactoryTest is Test, MockSetup {
         uint[] memory nums = new uint[](0);
         int24[] memory ticks = new int24[](0);
 
-        factory.setVaultConfig(
-            IFactory.VaultConfig({
-                vaultType: VaultTypeLib.COMPOUNDING,
-                implementation: address(vaultImplementation),
-                deployAllowed: true,
-                upgradeAllowed: true,
-                buildingPrice: builderPayPerVaultPrice
-            })
-        );
+        factory.setVaultImplementation(VaultTypeLib.COMPOUNDING, address(vaultImplementation));
 
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.DEV,
-                implementation: address(strategyImplementation),
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: false,
-                tokenId: type(uint).max
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.DEV, address(strategyImplementation));
 
         (, address strategy) = factory.deployVaultAndStrategy(
             VaultTypeLib.COMPOUNDING, StrategyIdLib.DEV, new address[](0), new uint[](0), addresses, nums, ticks
@@ -339,34 +273,14 @@ contract FactoryTest is Test, MockSetup {
             assertFalse(extra__[0] == bytes32(0));
         }
 
-        /*factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.DEV,
-                implementation: address(newStrategyImplementation),
-                deployAllowed: true,
-                upgradeAllowed: false,
-                farming: false,
-                tokenId: type(uint).max
-            }),
-            address(this)
-        );
+        /*factory.setStrategyImplementation(StrategyIdLib.DEV, address(strategyImplementation));
 
         strategyProxyHash = IStrategyProxy(strategy).strategyImplementationLogicIdHash();
         vm.expectRevert(abi.encodeWithSelector(IFactory.UpgradeDenied.selector, strategyProxyHash));
         factory.upgradeStrategyProxy(strategy);*/
 
         factory.setStrategyImplementation(StrategyIdLib.DEV, address(newStrategyImplementation));
-        /*factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.DEV,
-                implementation: address(newStrategyImplementation),
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: false,
-                tokenId: type(uint).max
-            }),
-            address(this)
-        );*/
+        /*factory.setStrategyImplementation(StrategyIdLib.DEV, address(strategyImplementation));*/
 
         vm.expectRevert(IControllable.NotFactory.selector);
         IStrategyProxy(strategy).upgrade();

--- a/test/core/MetaVault.MaxDeposit.MetaS.Sonic.t.sol
+++ b/test/core/MetaVault.MaxDeposit.MetaS.Sonic.t.sol
@@ -897,15 +897,7 @@ contract MetaVaultMaxDepositMetaSSonicTest is Test {
     function _updateCVaultImplementation(IFactory factory) internal {
         address vaultImplementation = address(new CVault());
         vm.prank(multisig);
-        factory.setVaultConfig(
-            IFactory.VaultConfig({
-                vaultType: VaultTypeLib.COMPOUNDING,
-                implementation: vaultImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                buildingPrice: 1e10
-            })
-        );
+        factory.setVaultImplementation(VaultTypeLib.COMPOUNDING, vaultImplementation);
     }
 
     function _upgradeMetaVault(address metaVault_) internal {

--- a/test/core/MetaVault.MaxDeposit.MetaS.Sonic.t.sol
+++ b/test/core/MetaVault.MaxDeposit.MetaS.Sonic.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.28;
 
-import {SonicLib} from "../../chains/sonic/SonicLib.sol";
 import {Factory} from "../../src/core/Factory.sol";
 import {MetaVault, IMetaVault, IStabilityVault, IPlatform, IPriceReader} from "../../src/core/vaults/MetaVault.sol";
 import {ERC4626Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC4626Upgradeable.sol";
@@ -79,7 +78,7 @@ contract MetaVaultMaxDepositMetaSSonicTest is Test {
             IFactory.StrategyAvailableInitParams memory p;
             factory.setStrategyAvailableInitParams(StrategyIdLib.SILO_ALMF_FARM, p);
         }
-        SonicLib._addStrategyLogic(factory, StrategyIdLib.SILO_ALMF_FARM, address(new SiloALMFStrategy()), true);
+        factory.setStrategyImplementation(StrategyIdLib.SILO_ALMF_FARM, address(new SiloALMFStrategy()));
         address[] memory _vaults = _createVaultsAndStrategies(factory);
         vm.stopPrank();
 

--- a/test/core/MetaVault.MaxDeposit.MetaUSD.Sonic.t.sol
+++ b/test/core/MetaVault.MaxDeposit.MetaUSD.Sonic.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.28;
 
-import {SonicLib} from "../../chains/sonic/SonicLib.sol";
 import {Factory} from "../../src/core/Factory.sol";
 import {MetaVault, IMetaVault, IStabilityVault, IPlatform, IPriceReader} from "../../src/core/vaults/MetaVault.sol";
 import {ERC4626Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC4626Upgradeable.sol";
@@ -79,7 +78,7 @@ contract MetaVaultMaxDepositMetaUsdSonicTest is Test {
             IFactory.StrategyAvailableInitParams memory p;
             factory.setStrategyAvailableInitParams(StrategyIdLib.SILO_ALMF_FARM, p);
         }
-        SonicLib._addStrategyLogic(factory, StrategyIdLib.SILO_ALMF_FARM, address(new SiloALMFStrategy()), true);
+        factory.setStrategyImplementation(StrategyIdLib.SILO_ALMF_FARM, address(new SiloALMFStrategy()));
         address[] memory _vaults = _createVaultsAndStrategies(factory);
         vm.stopPrank();
 

--- a/test/core/MetaVault.MaxDeposit.MetaUSD.Sonic.t.sol
+++ b/test/core/MetaVault.MaxDeposit.MetaUSD.Sonic.t.sol
@@ -1068,15 +1068,7 @@ contract MetaVaultMaxDepositMetaUsdSonicTest is Test {
     function _updateCVaultImplementation(IFactory factory) internal {
         address vaultImplementation = address(new CVault());
         vm.prank(multisig);
-        factory.setVaultConfig(
-            IFactory.VaultConfig({
-                vaultType: VaultTypeLib.COMPOUNDING,
-                implementation: vaultImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                buildingPrice: 1e10
-            })
-        );
+        factory.setVaultImplementation(VaultTypeLib.COMPOUNDING, vaultImplementation);
     }
 
     function _upgradeMetaVault(address metaVault_) internal {

--- a/test/core/MetaVault.Sonic.t.sol
+++ b/test/core/MetaVault.Sonic.t.sol
@@ -509,15 +509,7 @@ contract MetaVaultSonicTest is Test {
         // deploy new impl and upgrade
         address vaultImplementation = address(new CVault());
         vm.prank(multisig);
-        factory.setVaultConfig(
-            IFactory.VaultConfig({
-                vaultType: VaultTypeLib.COMPOUNDING,
-                implementation: vaultImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                buildingPrice: 1e10
-            })
-        );
+        factory.setVaultImplementation(VaultTypeLib.COMPOUNDING, vaultImplementation);
 
         factory.upgradeVaultProxy(SonicConstantsLib.VAULT_C_USDC_SIF);
         factory.upgradeVaultProxy(SonicConstantsLib.VAULT_C_USDC_SCUSD_ISF_SCUSD);
@@ -535,15 +527,7 @@ contract MetaVaultSonicTest is Test {
         // deploy new impl and upgrade
         address vaultImplementation = address(new CVault());
         vm.prank(multisig);
-        factory.setVaultConfig(
-            IFactory.VaultConfig({
-                vaultType: VaultTypeLib.COMPOUNDING,
-                implementation: vaultImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                buildingPrice: 1e10
-            })
-        );
+        factory.setVaultImplementation(VaultTypeLib.COMPOUNDING, vaultImplementation);
 
         address[8] memory vaults = [
             SonicConstantsLib.VAULT_C_USDC_SIF,
@@ -581,17 +565,7 @@ contract MetaVaultSonicTest is Test {
 
         address strategyImplementation = address(new SiloStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -601,17 +575,7 @@ contract MetaVaultSonicTest is Test {
 
         address strategyImplementation = address(new SiloFarmStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -621,17 +585,7 @@ contract MetaVaultSonicTest is Test {
 
         address strategyImplementation = address(new SiloManagedFarmStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO_MANAGED_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO_MANAGED_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -641,17 +595,7 @@ contract MetaVaultSonicTest is Test {
 
         address strategyImplementation = address(new IchiSwapXFarmStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.ICHI_SWAPX_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.ICHI_SWAPX_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }

--- a/test/core/MetaVault.Sonic.t.sol
+++ b/test/core/MetaVault.Sonic.t.sol
@@ -29,6 +29,8 @@ import {WrappedMetaVault} from "../../src/core/vaults/WrappedMetaVault.sol";
 import {SiloFarmStrategy} from "../../src/strategies/SiloFarmStrategy.sol";
 import {SiloStrategy} from "../../src/strategies/SiloStrategy.sol";
 import {IchiSwapXFarmStrategy} from "../../src/strategies/IchiSwapXFarmStrategy.sol";
+import {Factory} from "../../src/core/Factory.sol";
+import {IProxy} from "../../src/interfaces/IProxy.sol";
 
 contract MetaVaultSonicTest is Test {
     address public constant PLATFORM = SonicConstantsLib.PLATFORM;
@@ -40,6 +42,8 @@ contract MetaVaultSonicTest is Test {
     constructor() {
         // May-14-2025 10:14:19 PM +UTC
         vm.selectFork(vm.createFork(vm.envString("SONIC_RPC_URL"), 26834601));
+
+        _upgradeFactory(); // upgrade to Factory v2.0.0
     }
 
     function setUp() public {
@@ -657,5 +661,17 @@ contract MetaVaultSonicTest is Test {
             vm.prank(user);
             IERC20(assets[j]).approve(metavault, amounts[j]);
         }
+    }
+
+    function _upgradeFactory() internal {
+        // deploy new Factory implementation
+        address newImpl = address(new Factory());
+
+        // get the proxy address for the factory
+        address factoryProxy = address(IPlatform(PLATFORM).factory());
+
+        // prank as the platform because only it can upgrade
+        vm.prank(PLATFORM);
+        IProxy(factoryProxy).upgrade(newImpl);
     }
 }

--- a/test/core/MetaVault.Upgrade.360.WithdrawUnderlying.Sonic.t.sol
+++ b/test/core/MetaVault.Upgrade.360.WithdrawUnderlying.Sonic.t.sol
@@ -30,6 +30,8 @@ import {StrategyIdLib} from "../../src/strategies/libs/StrategyIdLib.sol";
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {VaultTypeLib} from "../../src/core/libs/VaultTypeLib.sol";
 import {console, Test} from "forge-std/Test.sol";
+import {Factory} from "../../src/core/Factory.sol";
+import {IProxy} from "../../src/interfaces/IProxy.sol";
 
 /// #360 - withdraw underlying from MetaVaults
 contract MetaVault360WithdrawUnderlyingSonicUpgrade is Test {
@@ -158,6 +160,7 @@ contract MetaVault360WithdrawUnderlyingSonicUpgrade is Test {
 
         _upgradePlatform();
         _setupMetaVaultFactory();
+        _upgradeFactory(); // upgrade to Factory v2.0.0
     }
 
     //region --------------------------------------- Tests for MetaUSDC/MetaScUSD (sub-meta-vaults)
@@ -1827,6 +1830,18 @@ contract MetaVault360WithdrawUnderlyingSonicUpgrade is Test {
         address recoveryTokenImplementation = address(new RecoveryToken());
         vm.prank(multisig);
         metaVaultFactory.setRecoveryTokenImplementation(recoveryTokenImplementation);
+    }
+
+    function _upgradeFactory() internal {
+        // deploy new Factory implementation
+        address newImpl = address(new Factory());
+
+        // get the proxy address for the factory
+        address factoryProxy = address(IPlatform(PLATFORM).factory());
+
+        // prank as the platform because only it can upgrade
+        vm.prank(PLATFORM);
+        IProxy(factoryProxy).upgrade(newImpl);
     }
     //endregion ---------------------------------------------- Helpers
 }

--- a/test/core/MetaVault.Upgrade.360.WithdrawUnderlying.Sonic.t.sol
+++ b/test/core/MetaVault.Upgrade.360.WithdrawUnderlying.Sonic.t.sol
@@ -1768,17 +1768,7 @@ contract MetaVault360WithdrawUnderlyingSonicUpgrade is Test {
         // deploy new impl and upgrade
         address strategyImplementation = address(new AaveMerklFarmStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.AAVE_MERKL_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: false,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.AAVE_MERKL_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategy_);
     }
@@ -1789,17 +1779,7 @@ contract MetaVault360WithdrawUnderlyingSonicUpgrade is Test {
         // deploy new impl and upgrade
         address strategyImplementation = address(new SiloStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: false,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategy_);
     }
@@ -1810,15 +1790,7 @@ contract MetaVault360WithdrawUnderlyingSonicUpgrade is Test {
         // deploy new impl and upgrade
         address vaultImplementation = address(new CVault());
         vm.prank(multisig);
-        factory.setVaultConfig(
-            IFactory.VaultConfig({
-                vaultType: VaultTypeLib.COMPOUNDING,
-                implementation: vaultImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                buildingPrice: 1e10
-            })
-        );
+        factory.setVaultImplementation(VaultTypeLib.COMPOUNDING, vaultImplementation);
         factory.upgradeVaultProxy(address(cVault_));
     }
 

--- a/test/core/MetaVault.Upgrade.RemoveVault.Sonic.t.sol
+++ b/test/core/MetaVault.Upgrade.RemoveVault.Sonic.t.sol
@@ -400,15 +400,7 @@ contract MetaVaultSonicUpgradeRemoveVault is Test {
         // deploy new impl and upgrade
         address vaultImplementation = address(new CVault());
         vm.prank(multisig);
-        factory.setVaultConfig(
-            IFactory.VaultConfig({
-                vaultType: VaultTypeLib.COMPOUNDING,
-                implementation: vaultImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                buildingPrice: 1e10
-            })
-        );
+        factory.setVaultImplementation(VaultTypeLib.COMPOUNDING, vaultImplementation);
 
         address[] memory vaults = multiVault.vaults();
 
@@ -439,17 +431,7 @@ contract MetaVaultSonicUpgradeRemoveVault is Test {
 
         address strategyImplementation = address(new SiloStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -459,17 +441,7 @@ contract MetaVaultSonicUpgradeRemoveVault is Test {
 
         address strategyImplementation = address(new SiloFarmStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -479,17 +451,7 @@ contract MetaVaultSonicUpgradeRemoveVault is Test {
 
         address strategyImplementation = address(new SiloManagedFarmStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO_MANAGED_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO_MANAGED_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -499,17 +461,7 @@ contract MetaVaultSonicUpgradeRemoveVault is Test {
 
         address strategyImplementation = address(new IchiSwapXFarmStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.ICHI_SWAPX_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.ICHI_SWAPX_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -519,17 +471,7 @@ contract MetaVaultSonicUpgradeRemoveVault is Test {
 
         address strategyImplementation = address(new AaveStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.AAVE,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.AAVE, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }

--- a/test/core/MetaVault.Upgrade.Sonic.t.sol
+++ b/test/core/MetaVault.Upgrade.Sonic.t.sol
@@ -80,15 +80,7 @@ contract MetaVaultSonicUpgrade1 is Test {
         // deploy new impl and upgrade
         address vaultImplementation = address(new CVault());
         vm.prank(multisig);
-        factory.setVaultConfig(
-            IFactory.VaultConfig({
-                vaultType: VaultTypeLib.COMPOUNDING,
-                implementation: vaultImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                buildingPrice: 1e10
-            })
-        );
+        factory.setVaultImplementation(VaultTypeLib.COMPOUNDING, vaultImplementation);
 
         address[8] memory vaults = [
             SonicConstantsLib.VAULT_C_USDC_SIF,
@@ -125,17 +117,7 @@ contract MetaVaultSonicUpgrade1 is Test {
 
         address strategyImplementation = address(new SiloStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -145,17 +127,7 @@ contract MetaVaultSonicUpgrade1 is Test {
 
         address strategyImplementation = address(new SiloFarmStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -165,17 +137,7 @@ contract MetaVaultSonicUpgrade1 is Test {
 
         address strategyImplementation = address(new IchiSwapXFarmStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.ICHI_SWAPX_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.ICHI_SWAPX_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }

--- a/test/core/MetaVault.UpgradeAudit.Sonic.t.sol
+++ b/test/core/MetaVault.UpgradeAudit.Sonic.t.sol
@@ -12,6 +12,8 @@ import {IFactory} from "../../src/interfaces/IFactory.sol";
 import {CVault} from "../../src/core/vaults/CVault.sol";
 import {IPriceReader} from "../../src/interfaces/IPriceReader.sol";
 import {VaultTypeLib} from "../../src/core/libs/VaultTypeLib.sol";
+import {Factory} from "../../src/core/Factory.sol";
+import {IProxy} from "../../src/interfaces/IProxy.sol";
 
 /// @dev Upgrade MetaVault after fixing the issues found in the audit
 contract MetaVaultSonicUpgradeAudit is Test {
@@ -30,6 +32,8 @@ contract MetaVaultSonicUpgradeAudit is Test {
         multisig = IPlatform(PLATFORM).multisig();
 
         priceReader = IPriceReader(IPlatform(PLATFORM).priceReader());
+
+        _upgradeFactory(); // upgrade to Factory v2.0.0
     }
 
     /// @notice #303: Fix slippage check in meta vault, 3.1.3 in audit report
@@ -287,6 +291,18 @@ contract MetaVaultSonicUpgradeAudit is Test {
                 }
             }
         }
+    }
+
+    function _upgradeFactory() internal {
+        // deploy new Factory implementation
+        address newImpl = address(new Factory());
+
+        // get the proxy address for the factory
+        address factoryProxy = address(IPlatform(PLATFORM).factory());
+
+        // prank as the platform because only it can upgrade
+        vm.prank(PLATFORM);
+        IProxy(factoryProxy).upgrade(newImpl);
     }
     //endregion ------------------------------ Auxiliary Functions
 }

--- a/test/core/MetaVault.UpgradeAudit.Sonic.t.sol
+++ b/test/core/MetaVault.UpgradeAudit.Sonic.t.sol
@@ -278,15 +278,7 @@ contract MetaVaultSonicUpgradeAudit is Test {
                 for (uint j = 0; j < vaults.length; j++) {
                     address vaultImplementation = address(new CVault());
                     vm.prank(multisig);
-                    factory.setVaultConfig(
-                        IFactory.VaultConfig({
-                            vaultType: VaultTypeLib.COMPOUNDING,
-                            implementation: vaultImplementation,
-                            deployAllowed: true,
-                            upgradeAllowed: true,
-                            buildingPrice: 1e10
-                        })
-                    );
+                    factory.setVaultImplementation(VaultTypeLib.COMPOUNDING, vaultImplementation);
                     vm.prank(multisig);
                     factory.upgradeVaultProxy(vaults[j]);
 

--- a/test/core/MetaVaultFactory.Sonic.t.sol
+++ b/test/core/MetaVaultFactory.Sonic.t.sol
@@ -17,6 +17,8 @@ import {CVault} from "../../src/core/vaults/CVault.sol";
 import {WrappedMetaVault} from "../../src/core/vaults/WrappedMetaVault.sol";
 import {MockMetaVaultUpgrade} from "../../src/test/MockMetaVaultUpgrade.sol";
 import {MockWrappedMetaVaultUpgrade} from "../../src/test/MockWrappedMetaVaultUpgrade.sol";
+import {Factory} from "../../src/core/Factory.sol";
+import {IProxy} from "../../src/interfaces/IProxy.sol";
 
 contract MetaVaultFactoryTest is Test {
     address public constant PLATFORM = SonicConstantsLib.PLATFORM;
@@ -26,6 +28,8 @@ contract MetaVaultFactoryTest is Test {
     constructor() {
         // May-10-2025 10:38:26 AM +UTC
         vm.selectFork(vm.createFork(vm.envString("SONIC_RPC_URL"), 25729900));
+
+        _upgradeFactory(); // upgrade to Factory v2.0.0
     }
 
     function setUp() public {
@@ -164,5 +168,17 @@ contract MetaVaultFactoryTest is Test {
             bytesArray[i] = _bytes32[i];
         }
         return string(bytesArray);
+    }
+
+    function _upgradeFactory() internal {
+        // deploy new Factory implementation
+        address newImpl = address(new Factory());
+
+        // get the proxy address for the factory
+        address factoryProxy = address(IPlatform(PLATFORM).factory());
+
+        // prank as the platform because only it can upgrade
+        vm.prank(PLATFORM);
+        IProxy(factoryProxy).upgrade(newImpl);
     }
 }

--- a/test/core/MetaVaultFactory.Sonic.t.sol
+++ b/test/core/MetaVaultFactory.Sonic.t.sol
@@ -142,15 +142,7 @@ contract MetaVaultFactoryTest is Test {
         // deploy new impl and upgrade
         address vaultImplementation = address(new CVault());
         vm.prank(multisig);
-        factory.setVaultConfig(
-            IFactory.VaultConfig({
-                vaultType: VaultTypeLib.COMPOUNDING,
-                implementation: vaultImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                buildingPrice: 1e10
-            })
-        );
+        factory.setVaultImplementation(VaultTypeLib.COMPOUNDING, vaultImplementation);
 
         factory.upgradeVaultProxy(SonicConstantsLib.VAULT_C_USDC_SIF);
         factory.upgradeVaultProxy(SonicConstantsLib.VAULT_C_USDC_SCUSD_ISF_SCUSD);

--- a/test/core/Platform.Polygon.t.sol
+++ b/test/core/Platform.Polygon.t.sol
@@ -432,17 +432,7 @@ contract PlatformPolygonTest is PolygonSetup {
     function _disableStrategy(string memory id) internal {
         vm.startPrank(platform.multisig());
         // platform.addOperator(platform.multisig());
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: id,
-                implementation: address(0),
-                deployAllowed: false,
-                upgradeAllowed: false,
-                farming: true,
-                tokenId: type(uint).max
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(id, address(0));
         vm.stopPrank();
     }
 

--- a/test/core/Wrapper.MetaS.Restart.Sonic.t.sol
+++ b/test/core/Wrapper.MetaS.Restart.Sonic.t.sol
@@ -929,17 +929,7 @@ contract WrapperMetaSRestartSonicTest is Test {
         // deploy new impl and upgrade
         address strategyImplementation = address(new AaveMerklFarmStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.AAVE_MERKL_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: false,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.AAVE_MERKL_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategy_);
     }
@@ -950,17 +940,7 @@ contract WrapperMetaSRestartSonicTest is Test {
         // deploy new impl and upgrade
         address strategyImplementation = address(new SiloStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: false,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategy_);
     }
@@ -971,15 +951,7 @@ contract WrapperMetaSRestartSonicTest is Test {
         // deploy new impl and upgrade
         address vaultImplementation = address(new CVault());
         vm.prank(multisig);
-        factory.setVaultConfig(
-            IFactory.VaultConfig({
-                vaultType: VaultTypeLib.COMPOUNDING,
-                implementation: vaultImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                buildingPrice: 1e10
-            })
-        );
+        factory.setVaultImplementation(VaultTypeLib.COMPOUNDING, vaultImplementation);
         factory.upgradeVaultProxy(address(cVault_));
     }
 

--- a/test/core/Wrapper.MetaS.Restart.Sonic.t.sol
+++ b/test/core/Wrapper.MetaS.Restart.Sonic.t.sol
@@ -24,6 +24,8 @@ import {VaultTypeLib} from "../../src/core/libs/VaultTypeLib.sol";
 import {WrappedMetaVault} from "../../src/core/vaults/WrappedMetaVault.sol";
 import {MetaVaultFactory} from "../../src/core/MetaVaultFactory.sol";
 import {console, Test} from "forge-std/Test.sol";
+import {Factory} from "../../src/core/Factory.sol";
+import {IProxy} from "../../src/interfaces/IProxy.sol";
 
 contract WrapperMetaSRestartSonicTest is Test {
     // uint public constant FORK_BLOCK = 42601861; // Aug-12-2025 03:58:17 AM +UTC
@@ -196,6 +198,8 @@ contract WrapperMetaSRestartSonicTest is Test {
             0x093308DC6b31e4bfE980405ae8a80748fCd3E4b7,
             0x88888887C3ebD4a33E34a15Db4254C74C75E5D4A
         ];
+
+        _upgradeFactory(); // upgrade to Factory v2.0.0
     }
 
     /// @notice Restart MetaS: withdraw all broken underlying, replace it by real assets and recovery tokens
@@ -1040,6 +1044,18 @@ contract WrapperMetaSRestartSonicTest is Test {
         address recoveryTokenImplementation = address(new RecoveryToken());
         vm.prank(multisig);
         metaVaultFactory.setRecoveryTokenImplementation(recoveryTokenImplementation);
+    }
+
+    function _upgradeFactory() internal {
+        // deploy new Factory implementation
+        address newImpl = address(new Factory());
+
+        // get the proxy address for the factory
+        address factoryProxy = address(IPlatform(PLATFORM).factory());
+
+        // prank as the platform because only it can upgrade
+        vm.prank(PLATFORM);
+        IProxy(factoryProxy).upgrade(newImpl);
     }
 
     //endregion ---------------------------------------------- Helpers

--- a/test/core/Wrapper.MetaUSD.Restart.Sonic.t.sol
+++ b/test/core/Wrapper.MetaUSD.Restart.Sonic.t.sol
@@ -24,6 +24,8 @@ import {VaultTypeLib} from "../../src/core/libs/VaultTypeLib.sol";
 import {WrappedMetaVault} from "../../src/core/vaults/WrappedMetaVault.sol";
 import {MetaVaultFactory} from "../../src/core/MetaVaultFactory.sol";
 import {console, Test} from "forge-std/Test.sol";
+import {Factory} from "../../src/core/Factory.sol";
+import {IProxy} from "../../src/interfaces/IProxy.sol";
 
 contract WrapperMetaUsdRestartSonicTest is Test {
     // uint public constant FORK_BLOCK = 42601861; // Aug-12-2025 03:58:17 AM +UTC
@@ -299,6 +301,8 @@ contract WrapperMetaUsdRestartSonicTest is Test {
             0xf63361925255c17C53E2303Ce167145D4cBD0c9C,
             0x43da58c65F0fadd0A94EdD85A9b018542BAd4223
         ];
+
+        _upgradeFactory(); // upgrade to Factory v2.0.0
     }
 
     /// @notice Restart MetaUSD: withdraw all broken underlying, replace it by real assets and recovery tokens
@@ -1251,6 +1255,18 @@ contract WrapperMetaUsdRestartSonicTest is Test {
         address recoveryTokenImplementation = address(new RecoveryToken());
         vm.prank(multisig);
         metaVaultFactory.setRecoveryTokenImplementation(recoveryTokenImplementation);
+    }
+
+    function _upgradeFactory() internal {
+        // deploy new Factory implementation
+        address newImpl = address(new Factory());
+
+        // get the proxy address for the factory
+        address factoryProxy = address(IPlatform(PLATFORM).factory());
+
+        // prank as the platform because only it can upgrade
+        vm.prank(PLATFORM);
+        IProxy(factoryProxy).upgrade(newImpl);
     }
 
     //endregion ---------------------------------------------- Helpers

--- a/test/core/Wrapper.MetaUSD.Restart.Sonic.t.sol
+++ b/test/core/Wrapper.MetaUSD.Restart.Sonic.t.sol
@@ -1142,17 +1142,7 @@ contract WrapperMetaUsdRestartSonicTest is Test {
         // deploy new impl and upgrade
         address strategyImplementation = address(new AaveMerklFarmStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.AAVE_MERKL_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: false,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.AAVE_MERKL_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategy_);
     }
@@ -1163,17 +1153,7 @@ contract WrapperMetaUsdRestartSonicTest is Test {
         // deploy new impl and upgrade
         address strategyImplementation = address(new SiloStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: false,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategy_);
     }
@@ -1184,15 +1164,7 @@ contract WrapperMetaUsdRestartSonicTest is Test {
         // deploy new impl and upgrade
         address vaultImplementation = address(new CVault());
         vm.prank(multisig);
-        factory.setVaultConfig(
-            IFactory.VaultConfig({
-                vaultType: VaultTypeLib.COMPOUNDING,
-                implementation: vaultImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                buildingPrice: 1e10
-            })
-        );
+        factory.setVaultImplementation(VaultTypeLib.COMPOUNDING, vaultImplementation);
         factory.upgradeVaultProxy(address(cVault_));
     }
 

--- a/test/core/Wrapper.metaUSD.MaxDeposit.Upgrade.Sonic.t.sol
+++ b/test/core/Wrapper.metaUSD.MaxDeposit.Upgrade.Sonic.t.sol
@@ -246,15 +246,7 @@ contract WrapperUsdMaxDepositUpgradeSonicTest is Test {
         // deploy new impl and upgrade
         address vaultImplementation = address(new CVault());
         vm.prank(multisig);
-        factory.setVaultConfig(
-            IFactory.VaultConfig({
-                vaultType: VaultTypeLib.COMPOUNDING,
-                implementation: vaultImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                buildingPrice: 1e10
-            })
-        );
+        factory.setVaultImplementation(VaultTypeLib.COMPOUNDING, vaultImplementation);
 
         if (upgradeStrategies_) {
             address[] memory vaults = metaVault_.vaults();
@@ -289,17 +281,7 @@ contract WrapperUsdMaxDepositUpgradeSonicTest is Test {
 
         address strategyImplementation = address(new AaveStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.AAVE,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.AAVE, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -309,17 +291,7 @@ contract WrapperUsdMaxDepositUpgradeSonicTest is Test {
 
         address strategyImplementation = address(new EulerStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.EULER,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.EULER, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -329,17 +301,7 @@ contract WrapperUsdMaxDepositUpgradeSonicTest is Test {
 
         address strategyImplementation = address(new SiloStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -349,17 +311,7 @@ contract WrapperUsdMaxDepositUpgradeSonicTest is Test {
 
         address strategyImplementation = address(new SiloFarmStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -369,17 +321,7 @@ contract WrapperUsdMaxDepositUpgradeSonicTest is Test {
 
         address strategyImplementation = address(new SiloManagedFarmStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO_MANAGED_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO_MANAGED_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }

--- a/test/core/Wrapper.metaUSD.MaxDeposit.Upgrade.Sonic.t.sol
+++ b/test/core/Wrapper.metaUSD.MaxDeposit.Upgrade.Sonic.t.sol
@@ -25,6 +25,8 @@ import {StrategyIdLib} from "../../src/strategies/libs/StrategyIdLib.sol";
 import {VaultTypeLib} from "../../src/core/libs/VaultTypeLib.sol";
 import {WrappedMetaVault} from "../../src/core/vaults/WrappedMetaVault.sol";
 import {console, Test} from "forge-std/Test.sol";
+import {Factory} from "../../src/core/Factory.sol";
+import {IProxy} from "../../src/interfaces/IProxy.sol";
 
 contract WrapperUsdMaxDepositUpgradeSonicTest is Test {
     uint public constant FORK_BLOCK = 33508152; // Jun-12-2025 05:49:24 AM +UTC
@@ -51,6 +53,8 @@ contract WrapperUsdMaxDepositUpgradeSonicTest is Test {
         metaVault = IMetaVault(SonicConstantsLib.METAVAULT_METAUSD);
         multiVault = IMetaVault(SonicConstantsLib.METAVAULT_METAUSDC);
         wrappedMetaVault = IWrappedMetaVault(SonicConstantsLib.WRAPPED_METAVAULT_METAUSD);
+
+        _upgradeFactory(); // upgrade to Factory v2.0.0
     }
 
     /// @notice #326, #334: Check how maxWithdraw works in wrapped/meta-vault/multi-vault/c-vault with AAVE strategy
@@ -397,6 +401,18 @@ contract WrapperUsdMaxDepositUpgradeSonicTest is Test {
         for (uint i; i < current.length; ++i) {
             console.log("i, current, target", i, current[i], props[i]);
         }
+    }
+
+    function _upgradeFactory() internal {
+        // deploy new Factory implementation
+        address newImpl = address(new Factory());
+
+        // get the proxy address for the factory
+        address factoryProxy = address(IPlatform(PLATFORM).factory());
+
+        // prank as the platform because only it can upgrade
+        vm.prank(PLATFORM);
+        IProxy(factoryProxy).upgrade(newImpl);
     }
     //endregion ---------------------- Auxiliary functions
 }

--- a/test/core/Wrapper.metaUSDC.ERC4626.Upgrade.Sonic.t.sol
+++ b/test/core/Wrapper.metaUSDC.ERC4626.Upgrade.Sonic.t.sol
@@ -120,15 +120,7 @@ contract WrapperERC4626SonicTest is ERC4626UniversalTest, SlippageTestUtils {
         // deploy new impl and upgrade
         address vaultImplementation = address(new CVault());
         vm.prank(multisig);
-        factory.setVaultConfig(
-            IFactory.VaultConfig({
-                vaultType: VaultTypeLib.COMPOUNDING,
-                implementation: vaultImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                buildingPrice: 1e10
-            })
-        );
+        factory.setVaultImplementation(VaultTypeLib.COMPOUNDING, vaultImplementation);
 
         address[5] memory vaults = [
             SonicConstantsLib.VAULT_C_USDC_SIF,
@@ -153,17 +145,7 @@ contract WrapperERC4626SonicTest is ERC4626UniversalTest, SlippageTestUtils {
 
         address strategyImplementation = address(new SiloStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -173,17 +155,7 @@ contract WrapperERC4626SonicTest is ERC4626UniversalTest, SlippageTestUtils {
 
         address strategyImplementation = address(new SiloFarmStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }

--- a/test/core/Wrapper.metaUSDC.ERC4626.Upgrade.Sonic.t.sol
+++ b/test/core/Wrapper.metaUSDC.ERC4626.Upgrade.Sonic.t.sol
@@ -18,6 +18,8 @@ import {VaultTypeLib} from "../../src/core/libs/VaultTypeLib.sol";
 import {CommonLib} from "../../src/core/libs/CommonLib.sol";
 import {StrategyIdLib} from "../../src/strategies/libs/StrategyIdLib.sol";
 import {SiloFarmStrategy} from "../../src/strategies/SiloFarmStrategy.sol";
+import {Factory} from "../../src/core/Factory.sol";
+import {IProxy} from "../../src/interfaces/IProxy.sol";
 
 contract WrapperERC4626SonicTest is ERC4626UniversalTest, SlippageTestUtils {
     address public constant PLATFORM = SonicConstantsLib.PLATFORM;
@@ -98,6 +100,7 @@ contract WrapperERC4626SonicTest is ERC4626UniversalTest, SlippageTestUtils {
         }
         vm.stopPrank();
 
+        _upgradeFactory(); // upgrade to Factory v2.0.0
         _upgradeCVaults();
 
         // to withdraw from requested subvault, i.e. 4
@@ -170,6 +173,18 @@ contract WrapperERC4626SonicTest is ERC4626UniversalTest, SlippageTestUtils {
 
         vm.prank(multisig);
         metaVault.setTargetProportions(props);
+    }
+
+    function _upgradeFactory() internal {
+        // deploy new Factory implementation
+        address newImpl = address(new Factory());
+
+        // get the proxy address for the factory
+        address factoryProxy = address(IPlatform(PLATFORM).factory());
+
+        // prank as the platform because only it can upgrade
+        vm.prank(PLATFORM);
+        IProxy(factoryProxy).upgrade(newImpl);
     }
     //endregion ---------------------- Auxiliary functions
 }

--- a/test/core/Wrapper.metascUSD.ERC4626.Upgrade.Sonic.t.sol
+++ b/test/core/Wrapper.metascUSD.ERC4626.Upgrade.Sonic.t.sol
@@ -115,15 +115,7 @@ contract WrapperERC4626scUSDSonicTest is ERC4626UniversalTest, SlippageTestUtils
         // deploy new impl and upgrade
         address vaultImplementation = address(new CVault());
         vm.prank(multisig);
-        factory.setVaultConfig(
-            IFactory.VaultConfig({
-                vaultType: VaultTypeLib.COMPOUNDING,
-                implementation: vaultImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                buildingPrice: 1e10
-            })
-        );
+        factory.setVaultImplementation(VaultTypeLib.COMPOUNDING, vaultImplementation);
 
         address[3] memory vaults = [
             SonicConstantsLib.VAULT_C_SCUSD_S_46,
@@ -146,17 +138,7 @@ contract WrapperERC4626scUSDSonicTest is ERC4626UniversalTest, SlippageTestUtils
 
         address strategyImplementation = address(new EulerStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.EULER,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.EULER, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -166,17 +148,7 @@ contract WrapperERC4626scUSDSonicTest is ERC4626UniversalTest, SlippageTestUtils
 
         address strategyImplementation = address(new SiloStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }

--- a/test/core/Wrapper.metascUSD.MaxDeposit.Upgrade.Sonic.t.sol
+++ b/test/core/Wrapper.metascUSD.MaxDeposit.Upgrade.Sonic.t.sol
@@ -257,15 +257,7 @@ contract WrapperScUsdMaxDepositUpgradeSonicTest is Test {
         // deploy new impl and upgrade
         address vaultImplementation = address(new CVault());
         vm.prank(multisig);
-        factory.setVaultConfig(
-            IFactory.VaultConfig({
-                vaultType: VaultTypeLib.COMPOUNDING,
-                implementation: vaultImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                buildingPrice: 1e10
-            })
-        );
+        factory.setVaultImplementation(VaultTypeLib.COMPOUNDING, vaultImplementation);
 
         address[3] memory vaults = [
             SonicConstantsLib.VAULT_C_SCUSD_S_46,
@@ -290,17 +282,7 @@ contract WrapperScUsdMaxDepositUpgradeSonicTest is Test {
 
         address strategyImplementation = address(new EulerStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.EULER,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.EULER, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -310,17 +292,7 @@ contract WrapperScUsdMaxDepositUpgradeSonicTest is Test {
 
         address strategyImplementation = address(new SiloStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }

--- a/test/core/Wrapper.metascUSD.MaxDeposit.Upgrade.Sonic.t.sol
+++ b/test/core/Wrapper.metascUSD.MaxDeposit.Upgrade.Sonic.t.sol
@@ -23,6 +23,8 @@ import {StrategyIdLib} from "../../src/strategies/libs/StrategyIdLib.sol";
 import {VaultTypeLib} from "../../src/core/libs/VaultTypeLib.sol";
 import {WrappedMetaVault} from "../../src/core/vaults/WrappedMetaVault.sol";
 import {Test} from "forge-std/Test.sol";
+import {Factory} from "../../src/core/Factory.sol";
+import {IProxy} from "../../src/interfaces/IProxy.sol";
 
 contract WrapperScUsdMaxDepositUpgradeSonicTest is Test {
     uint public constant FORK_BLOCK = 34657318; // Jun-12-2025 05:49:24 AM +UTC
@@ -44,6 +46,8 @@ contract WrapperScUsdMaxDepositUpgradeSonicTest is Test {
 
         metaVault = IMetaVault(SonicConstantsLib.METAVAULT_METASCUSD);
         wrappedMetaVault = IWrappedMetaVault(SonicConstantsLib.WRAPPED_METAVAULT_METASCUSD);
+
+        _upgradeFactory(); // upgrade to Factory v2.0.0
     }
 
     /// @notice #326, #334: Check how maxWithdraw works in wrapped/meta-vault/c-vault with Euler strategy
@@ -380,6 +384,18 @@ contract WrapperScUsdMaxDepositUpgradeSonicTest is Test {
 
         // _showProportions(metaVault_);
         // console.log(metaVault_.vaultForDeposit(), metaVault_.vaultForWithdraw());
+    }
+
+    function _upgradeFactory() internal {
+        // deploy new Factory implementation
+        address newImpl = address(new Factory());
+
+        // get the proxy address for the factory
+        address factoryProxy = address(IPlatform(PLATFORM).factory());
+
+        // prank as the platform because only it can upgrade
+        vm.prank(PLATFORM);
+        IProxy(factoryProxy).upgrade(newImpl);
     }
     //endregion ---------------------- Auxiliary functions
 }

--- a/test/strategies/A.Upgrade.360.Sonic.t.sol
+++ b/test/strategies/A.Upgrade.360.Sonic.t.sol
@@ -15,6 +15,8 @@ import {IAToken} from "../../src/integrations/aave/IAToken.sol";
 import {IPriceReader} from "../../src/interfaces/IPriceReader.sol";
 import {AaveStrategy} from "../../src/strategies/AaveStrategy.sol";
 import {StrategyIdLib} from "../../src/strategies/libs/StrategyIdLib.sol";
+import {Factory} from "../../src/core/Factory.sol";
+import {IProxy} from "../../src/interfaces/IProxy.sol";
 
 /// @notice #360 - Add support of underlying operations to Aave strategy
 contract AUpgrade360Test is Test {
@@ -33,6 +35,8 @@ contract AUpgrade360Test is Test {
         multisig = IPlatform(PLATFORM).multisig();
 
         priceReader = IPriceReader(IPlatform(PLATFORM).priceReader());
+
+        _upgradeFactory(); // upgrade to Factory v2.0.0
     }
 
     /// @notice Try to deposit/withdraw underlying from the vault with Aave strategy
@@ -141,6 +145,18 @@ contract AUpgrade360Test is Test {
             vm.prank(user);
             IERC20(assets[j]).approve(spender, amounts[j]);
         }
+    }
+
+    function _upgradeFactory() internal {
+        // deploy new Factory implementation
+        address newImpl = address(new Factory());
+
+        // get the proxy address for the factory
+        address factoryProxy = address(IPlatform(PLATFORM).factory());
+
+        // prank as the platform because only it can upgrade
+        vm.prank(PLATFORM);
+        IProxy(factoryProxy).upgrade(newImpl);
     }
     //endregion ------------------------------ Auxiliary Functions
 }

--- a/test/strategies/A.Upgrade.360.Sonic.t.sol
+++ b/test/strategies/A.Upgrade.360.Sonic.t.sol
@@ -97,17 +97,7 @@ contract AUpgrade360Test is Test {
 
         address strategyImplementation = address(new AaveStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.AAVE,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.AAVE, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }

--- a/test/strategies/A.Upgrade.Sonic.t.sol
+++ b/test/strategies/A.Upgrade.Sonic.t.sol
@@ -106,15 +106,7 @@ contract AUpgradeTest is Test {
         // deploy new impl and upgrade
         address vaultImplementation = address(new CVault());
         vm.prank(multisig);
-        factory.setVaultConfig(
-            IFactory.VaultConfig({
-                vaultType: VaultTypeLib.COMPOUNDING,
-                implementation: vaultImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                buildingPrice: 1e10
-            })
-        );
+        factory.setVaultImplementation(VaultTypeLib.COMPOUNDING, vaultImplementation);
 
         factory.upgradeVaultProxy(vault);
     }
@@ -124,17 +116,7 @@ contract AUpgradeTest is Test {
 
         address strategyImplementation = address(new AaveStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.AAVE,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.AAVE, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }

--- a/test/strategies/A.Upgrade.Sonic.t.sol
+++ b/test/strategies/A.Upgrade.Sonic.t.sol
@@ -17,6 +17,8 @@ import {IPriceReader} from "../../src/interfaces/IPriceReader.sol";
 import {VaultTypeLib} from "../../src/core/libs/VaultTypeLib.sol";
 import {AaveStrategy} from "../../src/strategies/AaveStrategy.sol";
 import {StrategyIdLib} from "../../src/strategies/libs/StrategyIdLib.sol";
+import {Factory} from "../../src/core/Factory.sol";
+import {IProxy} from "../../src/interfaces/IProxy.sol";
 
 contract AUpgradeTest is Test {
     uint public constant FORK_BLOCK = 33508152; // Jun-12-2025 05:49:24 AM +UTC
@@ -34,6 +36,8 @@ contract AUpgradeTest is Test {
         multisig = IPlatform(PLATFORM).multisig();
 
         priceReader = IPriceReader(IPlatform(PLATFORM).priceReader());
+
+        _upgradeFactory(); // upgrade to Factory v2.0.0
     }
 
     /// @notice #326: Metavault is not able to withdraw from Aave strategy all amount because of the lack of liquidity in aToken
@@ -119,6 +123,18 @@ contract AUpgradeTest is Test {
         factory.setStrategyImplementation(StrategyIdLib.AAVE, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
+    }
+
+    function _upgradeFactory() internal {
+        // deploy new Factory implementation
+        address newImpl = address(new Factory());
+
+        // get the proxy address for the factory
+        address factoryProxy = address(IPlatform(PLATFORM).factory());
+
+        // prank as the platform because only it can upgrade
+        vm.prank(PLATFORM);
+        IProxy(factoryProxy).upgrade(newImpl);
     }
     //endregion ------------------------------ Auxiliary Functions
 }

--- a/test/strategies/AMF.Upgrade.360.Sonic.t.sol
+++ b/test/strategies/AMF.Upgrade.360.Sonic.t.sol
@@ -15,6 +15,8 @@ import {IAToken} from "../../src/integrations/aave/IAToken.sol";
 import {IPriceReader} from "../../src/interfaces/IPriceReader.sol";
 import {AaveMerklFarmStrategy} from "../../src/strategies/AaveMerklFarmStrategy.sol";
 import {StrategyIdLib} from "../../src/strategies/libs/StrategyIdLib.sol";
+import {Factory} from "../../src/core/Factory.sol";
+import {IProxy} from "../../src/interfaces/IProxy.sol";
 
 /// @notice #360 - Add support of underlying operations to AaveMerklFarmStrategy strategy
 contract AMFUpgrade360Test is Test {
@@ -33,6 +35,8 @@ contract AMFUpgrade360Test is Test {
         multisig = IPlatform(PLATFORM).multisig();
 
         priceReader = IPriceReader(IPlatform(PLATFORM).priceReader());
+
+        _upgradeFactory(); // upgrade to Factory v2.0.0
     }
 
     /// @notice Try to deposit/withdraw underlying from the vault with AMF strategy
@@ -143,6 +147,18 @@ contract AMFUpgrade360Test is Test {
             vm.prank(user);
             IERC20(assets[j]).approve(spender, amounts[j]);
         }
+    }
+
+    function _upgradeFactory() internal {
+        // deploy new Factory implementation
+        address newImpl = address(new Factory());
+
+        // get the proxy address for the factory
+        address factoryProxy = address(IPlatform(PLATFORM).factory());
+
+        // prank as the platform because only it can upgrade
+        vm.prank(PLATFORM);
+        IProxy(factoryProxy).upgrade(newImpl);
     }
     //endregion ------------------------------ Auxiliary Functions
 }

--- a/test/strategies/AMF.Upgrade.360.Sonic.t.sol
+++ b/test/strategies/AMF.Upgrade.360.Sonic.t.sol
@@ -99,17 +99,7 @@ contract AMFUpgrade360Test is Test {
 
         address strategyImplementation = address(new AaveMerklFarmStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.AAVE_MERKL_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.AAVE_MERKL_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }

--- a/test/strategies/ASF.Upgrade1.Sonic.t.sol
+++ b/test/strategies/ASF.Upgrade1.Sonic.t.sol
@@ -48,17 +48,7 @@ contract ASFUpgrade1Test is Test {
         // deploy new impl and upgrade
         address strategyImplementation = address(new ALMShadowFarmStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.ALM_SHADOW_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.ALM_SHADOW_FARM, strategyImplementation);
         factory.upgradeStrategyProxy(STRATEGY);
 
         proportions = IStrategy(STRATEGY).getAssetsProportions();

--- a/test/strategies/ASF.Upgrade1.Sonic.t.sol
+++ b/test/strategies/ASF.Upgrade1.Sonic.t.sol
@@ -11,6 +11,8 @@ import {IStrategy} from "../../src/interfaces/IStrategy.sol";
 import {IControllable} from "../../src/interfaces/IControllable.sol";
 import {IFactory} from "../../src/interfaces/IFactory.sol";
 import {IPlatform} from "../../src/interfaces/IPlatform.sol";
+import {Factory} from "../../src/core/Factory.sol";
+import {IProxy} from "../../src/interfaces/IProxy.sol";
 
 contract ASFUpgrade1Test is Test {
     address public constant PLATFORM = 0x4Aca671A420eEB58ecafE83700686a2AD06b20D8;
@@ -27,6 +29,7 @@ contract ASFUpgrade1Test is Test {
         multisig = IPlatform(IControllable(STRATEGY).platform()).multisig();
         zap = IPlatform(IControllable(STRATEGY).platform()).zap();
         factory = IFactory(IPlatform(IControllable(STRATEGY).platform()).factory());
+        _upgradeFactory(); // upgrade to Factory v2.0.0
     }
 
     function testASFBugfix1() public {
@@ -55,5 +58,20 @@ contract ASFUpgrade1Test is Test {
         //console.log(proportions[0], proportions[1]);
 
         IVault(vault).depositAssets(assets, amounts, 0, address(this));
+    }
+
+    function _upgradeFactory() internal {
+        // deploy new Factory implementation
+        address newImpl = address(new Factory());
+
+        // get the proxy address for the factory
+        address factoryProxy = address(IPlatform(PLATFORM).factory());
+
+        // prank as the platform because only it can upgrade
+        vm.prank(PLATFORM);
+        IProxy(factoryProxy).upgrade(newImpl);
+
+        // refresh the factory instance to point to the proxy (now using new impl)
+        factory = IFactory(factoryProxy);
     }
 }

--- a/test/strategies/ASF.Upgrade2.Sonic.t.sol
+++ b/test/strategies/ASF.Upgrade2.Sonic.t.sol
@@ -42,17 +42,7 @@ contract ASFUpgrade2Test is Test {
         // deploy new impl and upgrade
         address strategyImplementation = address(new ALMShadowFarmStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.ALM_SHADOW_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.ALM_SHADOW_FARM, strategyImplementation);
         factory.upgradeStrategyProxy(STRATEGY);
 
         IVault(vault).depositAssets(assets, amounts, 0, address(this));

--- a/test/strategies/ASF.Upgrade3.Sonic.t.sol
+++ b/test/strategies/ASF.Upgrade3.Sonic.t.sol
@@ -76,17 +76,7 @@ contract ASFUpgrade3Test is Test {
         // deploy new impl and upgrade
         address strategyImplementation = address(new ALMShadowFarmStrategy());
         vm.startPrank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.ALM_SHADOW_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.ALM_SHADOW_FARM, strategyImplementation);
         factory.upgradeStrategyProxy(STRATEGY);
         IFarmingStrategy(STRATEGY).refreshFarmingAssets();
         vm.stopPrank();

--- a/test/strategies/ASF.Upgrade4.Sonic.t.sol
+++ b/test/strategies/ASF.Upgrade4.Sonic.t.sol
@@ -57,17 +57,7 @@ contract ASFUpgrade4Test is Test {
         // Upgrade strategy
         address newImpl = address(new ALMShadowFarmStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.ALM_SHADOW_FARM,
-                implementation: newImpl,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.ALM_SHADOW_FARM, newImpl);
         factory.upgradeStrategyProxy(STRATEGY);
         // Deposit assets after upgrade
         IVault(vault).depositAssets(assets, amounts, 0, address(this));
@@ -92,17 +82,7 @@ contract ASFUpgrade4Test is Test {
         vm.prank(multisig);
         hw.setDedicatedServerMsgSender(address(this), true);
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.ALM_SHADOW_FARM,
-                implementation: newImpl,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.ALM_SHADOW_FARM, newImpl);
         factory.upgradeStrategyProxy(STRATEGY);
         address pool = ILPStrategy(STRATEGY).pool();
         address ammAdapter = address(ILPStrategy(STRATEGY).ammAdapter());
@@ -141,17 +121,7 @@ contract ASFUpgrade4Test is Test {
         vm.prank(multisig);
         hw.setDedicatedServerMsgSender(address(this), true);
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.ALM_SHADOW_FARM,
-                implementation: newImpl,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.ALM_SHADOW_FARM, newImpl);
         factory.upgradeStrategyProxy(STRATEGY);
         address pool = ILPStrategy(STRATEGY).pool();
         address ammAdapter = address(ILPStrategy(STRATEGY).ammAdapter());

--- a/test/strategies/ASF.Upgrade4.Sonic.t.sol
+++ b/test/strategies/ASF.Upgrade4.Sonic.t.sol
@@ -15,6 +15,8 @@ import {IPlatform} from "../../src/interfaces/IPlatform.sol";
 import {ISwapper} from "../../src/interfaces/ISwapper.sol";
 import {IUniswapV3Pool} from "../../src/integrations/uniswapv3/IUniswapV3Pool.sol";
 import {RebalanceHelper} from "../../src/periphery/RebalanceHelper.sol";
+import {Factory} from "../../src/core/Factory.sol";
+import {IProxy} from "../../src/interfaces/IProxy.sol";
 
 contract ASFUpgrade4Test is Test {
     address public constant PLATFORM = 0x4Aca671A420eEB58ecafE83700686a2AD06b20D8;
@@ -35,6 +37,7 @@ contract ASFUpgrade4Test is Test {
         factory = IFactory(IPlatform(PLATFORM).factory());
         swapper = ISwapper(IPlatform(PLATFORM).swapper());
         rebalanceHelper = new RebalanceHelper();
+        _upgradeFactory(); // upgrade to Factory v2.0.0
     }
 
     function getUniswapV3CurrentTick(address pool) public view returns (int24 tick) {
@@ -166,5 +169,20 @@ contract ASFUpgrade4Test is Test {
         // incrementing need for some tokens with custom fee
         deal(assets_[0], address(this), amount0 + 1);
         swapper.swapWithRoute(poolData, amount0, makePoolVolumePriceImpactTolerance);
+    }
+
+    function _upgradeFactory() internal {
+        // deploy new Factory implementation
+        address newImpl = address(new Factory());
+
+        // get the proxy address for the factory
+        address factoryProxy = address(IPlatform(PLATFORM).factory());
+
+        // prank as the platform because only it can upgrade
+        vm.prank(PLATFORM);
+        IProxy(factoryProxy).upgrade(newImpl);
+
+        // refresh the factory instance to point to the proxy (now using new impl)
+        factory = IFactory(factoryProxy);
     }
 }

--- a/test/strategies/DQMF.Upgrade.Polygon.t.sol
+++ b/test/strategies/DQMF.Upgrade.Polygon.t.sol
@@ -6,6 +6,8 @@ import {DefiEdgeQuickSwapMerklFarmStrategy} from "../../src/strategies/DefiEdgeQ
 import {PolygonLib, IFactory, IPlatform, StrategyIdLib} from "../../chains/PolygonLib.sol";
 import {IMerklDistributor} from "../../src/integrations/merkl/IMerklDistributor.sol";
 import {IMerklStrategy} from "../../src/interfaces/IMerklStrategy.sol";
+import {Factory} from "../../src/core/Factory.sol";
+import {IProxy} from "../../src/interfaces/IProxy.sol";
 
 contract DQMFUpgradeTest is Test {
     address public constant PLATFORM = 0xb2a0737ef27b5Cc474D24c779af612159b1c3e60;
@@ -14,6 +16,8 @@ contract DQMFUpgradeTest is Test {
     constructor() {
         vm.selectFork(vm.createFork(vm.envString("POLYGON_RPC_URL")));
         vm.rollFork(56967000); // May-14-2024 05:36:03 PM +UTC
+
+        _upgradeFactory(); // upgrade to Factory v2.0.0
     }
 
     function testDQMFUpgrade() public {
@@ -59,5 +63,17 @@ contract DQMFUpgradeTest is Test {
         IMerklStrategy(STRATEGY).toggleDistributorUserOperator(PolygonLib.MERKL_DISTRIBUTOR, address(this));
 
         IMerklDistributor(PolygonLib.MERKL_DISTRIBUTOR).claim(users, tokens, amounts, proofs);
+    }
+
+    function _upgradeFactory() internal {
+        // deploy new Factory implementation
+        address newImpl = address(new Factory());
+
+        // get the proxy address for the factory
+        address factoryProxy = address(IPlatform(PLATFORM).factory());
+
+        // prank as the platform because only it can upgrade
+        vm.prank(PLATFORM);
+        IProxy(factoryProxy).upgrade(newImpl);
     }
 }

--- a/test/strategies/DQMF.Upgrade.Polygon.t.sol
+++ b/test/strategies/DQMF.Upgrade.Polygon.t.sol
@@ -51,17 +51,7 @@ contract DQMFUpgradeTest is Test {
         // deploy new impl and upgrade
         address strategyImplementation = address(new DefiEdgeQuickSwapMerklFarmStrategy());
         vm.prank(operator);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.DEFIEDGE_QUICKSWAP_MERKL_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.DEFIEDGE_QUICKSWAP_MERKL_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(STRATEGY);
 

--- a/test/strategies/E.Upgrade.Sonic.t.sol
+++ b/test/strategies/E.Upgrade.Sonic.t.sol
@@ -152,15 +152,7 @@ contract EUpgradeTest is Test {
         // deploy new impl and upgrade
         address vaultImplementation = address(new CVault());
         vm.prank(multisig);
-        factory.setVaultConfig(
-            IFactory.VaultConfig({
-                vaultType: VaultTypeLib.COMPOUNDING,
-                implementation: vaultImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                buildingPrice: 1e10
-            })
-        );
+        factory.setVaultImplementation(VaultTypeLib.COMPOUNDING, vaultImplementation);
 
         factory.upgradeVaultProxy(vault);
     }
@@ -170,17 +162,7 @@ contract EUpgradeTest is Test {
 
         address strategyImplementation = address(new EulerStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.EULER,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.EULER, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }

--- a/test/strategies/EF.Upgrade.Sonic.t.sol
+++ b/test/strategies/EF.Upgrade.Sonic.t.sol
@@ -40,17 +40,7 @@ contract EFUpgradeTest is Test {
         // deploy new impl and upgrade
         address strategyImplementation = address(new EqualizerFarmStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.EQUALIZER_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.EQUALIZER_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(STRATEGY);
 

--- a/test/strategies/EF.Upgrade.Sonic.t.sol
+++ b/test/strategies/EF.Upgrade.Sonic.t.sol
@@ -8,6 +8,8 @@ import {IStrategy} from "../../src/interfaces/IStrategy.sol";
 import {IFactory} from "../../src/interfaces/IFactory.sol";
 import {StrategyIdLib} from "../../src/strategies/libs/StrategyIdLib.sol";
 import {EqualizerFarmStrategy} from "../../src/strategies/EqualizerFarmStrategy.sol";
+import {Factory} from "../../src/core/Factory.sol";
+import {IProxy} from "../../src/interfaces/IProxy.sol";
 
 contract EFUpgradeTest is Test {
     address public constant PLATFORM = 0x4Aca671A420eEB58ecafE83700686a2AD06b20D8;
@@ -16,6 +18,8 @@ contract EFUpgradeTest is Test {
     constructor() {
         vm.selectFork(vm.createFork(vm.envString("SONIC_RPC_URL")));
         vm.rollFork(2346485); // Jan-03-2025 10:36:37 AM +UTC
+
+        _upgradeFactory(); // upgrade to Factory v2.0.0
     }
 
     function testEFUpgrade() public {
@@ -46,5 +50,17 @@ contract EFUpgradeTest is Test {
 
         /// forge-lint: disable-next-line
         hw.call(vaultsForHardWork);
+    }
+
+    function _upgradeFactory() internal {
+        // deploy new Factory implementation
+        address newImpl = address(new Factory());
+
+        // get the proxy address for the factory
+        address factoryProxy = address(IPlatform(PLATFORM).factory());
+
+        // prank as the platform because only it can upgrade
+        vm.prank(PLATFORM);
+        IProxy(factoryProxy).upgrade(newImpl);
     }
 }

--- a/test/strategies/IQMF.Upgrade.Polygon.t.sol
+++ b/test/strategies/IQMF.Upgrade.Polygon.t.sol
@@ -39,17 +39,7 @@ contract IQMFUpgradeTest is Test {
         // deploy new impl and upgrade
         address strategyImplementation = address(new IchiQuickSwapMerklFarmStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.ICHI_QUICKSWAP_MERKL_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.ICHI_QUICKSWAP_MERKL_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(STRATEGY);
 

--- a/test/strategies/ISF.Upgrade.Sonic.t.sol
+++ b/test/strategies/ISF.Upgrade.Sonic.t.sol
@@ -33,17 +33,7 @@ contract ISFUpgradeTest is Test {
         // deploy new impl and upgrade
         address strategyImplementation = address(new IchiSwapXFarmStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.ICHI_SWAPX_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.ICHI_SWAPX_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(STRATEGY);
 

--- a/test/strategies/ISF.Upgrade2.Sonic.t.sol
+++ b/test/strategies/ISF.Upgrade2.Sonic.t.sol
@@ -27,17 +27,7 @@ contract ISFUpgrade2Test is Test {
         // deploy new impl and upgrade
         address strategyImplementation = address(new IchiSwapXFarmStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.ICHI_SWAPX_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.ICHI_SWAPX_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(STRATEGY);
 

--- a/test/strategies/ISF.Upgrade3.Sonic.t.sol
+++ b/test/strategies/ISF.Upgrade3.Sonic.t.sol
@@ -35,17 +35,7 @@ contract ISFUpgrade3Test is Test {
         // deploy new impl and upgrade
         address strategyImplementation = address(new IchiSwapXFarmStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.ICHI_SWAPX_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.ICHI_SWAPX_FARM, strategyImplementation);
         factory.upgradeStrategyProxy(STRATEGY);
 
         // update farm

--- a/test/strategies/SF.Upgrade.Sonic.t.sol
+++ b/test/strategies/SF.Upgrade.Sonic.t.sol
@@ -40,17 +40,7 @@ contract SFUpgradeTest is Test {
         // deploy new impl and upgrade
         address strategyImplementation = address(new SwapXFarmStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SWAPX_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SWAPX_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(STRATEGY);
 

--- a/test/strategies/Si.Upgrade.Sonic.t.sol
+++ b/test/strategies/Si.Upgrade.Sonic.t.sol
@@ -115,15 +115,7 @@ contract SiUpgradeTest is Test {
         // deploy new impl and upgrade
         address vaultImplementation = address(new CVault());
         vm.prank(multisig);
-        factory.setVaultConfig(
-            IFactory.VaultConfig({
-                vaultType: VaultTypeLib.COMPOUNDING,
-                implementation: vaultImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                buildingPrice: 1e10
-            })
-        );
+        factory.setVaultImplementation(VaultTypeLib.COMPOUNDING, vaultImplementation);
 
         factory.upgradeVaultProxy(vault);
     }
@@ -133,17 +125,7 @@ contract SiUpgradeTest is Test {
 
         address strategyImplementation = address(new SiloStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }

--- a/test/strategies/Si.Upgrade.Sonic.t.sol
+++ b/test/strategies/Si.Upgrade.Sonic.t.sol
@@ -17,6 +17,8 @@ import {SonicConstantsLib} from "../../chains/sonic/SonicConstantsLib.sol";
 import {StrategyIdLib} from "../../src/strategies/libs/StrategyIdLib.sol";
 import {VaultTypeLib} from "../../src/core/libs/VaultTypeLib.sol";
 import {Test} from "forge-std/Test.sol";
+import {Factory} from "../../src/core/Factory.sol";
+import {IProxy} from "../../src/interfaces/IProxy.sol";
 
 contract SiUpgradeTest is Test {
     uint public constant FORK_BLOCK = 33508152; // Jun-12-2025 05:49:24 AM +UTC
@@ -34,6 +36,8 @@ contract SiUpgradeTest is Test {
         multisig = IPlatform(PLATFORM).multisig();
 
         priceReader = IPriceReader(IPlatform(PLATFORM).priceReader());
+
+        _upgradeFactory(); // upgrade to Factory v2.0.0
     }
 
     /// @notice #326: Add maxWithdrawAssets and poolTvl to IStrategy
@@ -128,6 +132,18 @@ contract SiUpgradeTest is Test {
         factory.setStrategyImplementation(StrategyIdLib.SILO, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
+    }
+
+    function _upgradeFactory() internal {
+        // deploy new Factory implementation
+        address newImpl = address(new Factory());
+
+        // get the proxy address for the factory
+        address factoryProxy = address(IPlatform(PLATFORM).factory());
+
+        // prank as the platform because only it can upgrade
+        vm.prank(PLATFORM);
+        IProxy(factoryProxy).upgrade(newImpl);
     }
     //endregion ------------------------------ Auxiliary Functions
 }

--- a/test/strategies/SiAL.Upgrade.Expired.Pt.Single.Sonic.t.sol
+++ b/test/strategies/SiAL.Upgrade.Expired.Pt.Single.Sonic.t.sol
@@ -111,17 +111,7 @@ contract SiALUpgradeExpiredPtSingleTest is Test {
         // deploy new impl and upgrade
         address strategyImplementation = address(new SiloAdvancedLeverageStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO_ADVANCED_LEVERAGE,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO_ADVANCED_LEVERAGE, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategy_);
     }

--- a/test/strategies/SiAL.Upgrade.Expired.Pt.Sonic.t.sol
+++ b/test/strategies/SiAL.Upgrade.Expired.Pt.Sonic.t.sol
@@ -523,17 +523,7 @@ contract SiALUpgradeExpiredPtTest is Test {
         // deploy new impl and upgrade
         address strategyImplementation = address(new SiloAdvancedLeverageStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO_ADVANCED_LEVERAGE,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO_ADVANCED_LEVERAGE, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategy_);
     }

--- a/test/strategies/SiAL.Upgrade.Expired.Pt.Sonic.t.sol
+++ b/test/strategies/SiAL.Upgrade.Expired.Pt.Sonic.t.sol
@@ -16,6 +16,8 @@ import {console, Test} from "forge-std/Test.sol";
 import {PendleAdapter} from "../../src/adapters/PendleAdapter.sol";
 import {IPPrincipalToken} from "../../src/integrations/pendle/IPPrincipalToken.sol";
 import {SonicConstantsLib} from "../../chains/sonic/SonicConstantsLib.sol";
+import {Factory} from "../../src/core/Factory.sol";
+import {IProxy} from "../../src/interfaces/IProxy.sol";
 
 contract SiALUpgradeExpiredPtTest is Test {
     address public constant PLATFORM = 0x4Aca671A420eEB58ecafE83700686a2AD06b20D8;
@@ -101,6 +103,8 @@ contract SiALUpgradeExpiredPtTest is Test {
             0xb2D7f55037A303B9f6AF0729C1183B43FBb3CBb6,
             0x4138F7b064Dc467A7C801c8ce19B94C98120A473 // largest
         ];
+
+        _upgradeFactory(); // upgrade to Factory v2.0.0
     }
 
     //region ---------------------------------------- Test for TOKEN_PT_SILO_20_USDC_17JUL2025
@@ -586,6 +590,18 @@ contract SiALUpgradeExpiredPtTest is Test {
         //                console.log("maxLeverage", state.maxLeverage);
         //                console.log("targetLeverage", state.targetLeverage);
         return state;
+    }
+
+    function _upgradeFactory() internal {
+        // deploy new Factory implementation
+        address newImpl = address(new Factory());
+
+        // get the proxy address for the factory
+        address factoryProxy = address(IPlatform(PLATFORM).factory());
+
+        // prank as the platform because only it can upgrade
+        vm.prank(PLATFORM);
+        IProxy(factoryProxy).upgrade(newImpl);
     }
     //endregion ---------------------------------------- Helpers
 }

--- a/test/strategies/SiAL.Upgrade.MaxLtv.Sonic.t.sol
+++ b/test/strategies/SiAL.Upgrade.MaxLtv.Sonic.t.sol
@@ -148,15 +148,7 @@ contract SialUpgradeMaxLtvSonic is Test {
         // deploy new impl and upgrade
         address vaultImplementation = address(new CVault());
         vm.prank(multisig);
-        factory.setVaultConfig(
-            IFactory.VaultConfig({
-                vaultType: VaultTypeLib.COMPOUNDING,
-                implementation: vaultImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                buildingPrice: 1e10
-            })
-        );
+        factory.setVaultImplementation(VaultTypeLib.COMPOUNDING, vaultImplementation);
         factory.upgradeVaultProxy(address(vault_));
     }
 
@@ -173,17 +165,7 @@ contract SialUpgradeMaxLtvSonic is Test {
         address strategyImplementation = address(new SiloAdvancedLeverageStrategy());
 
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO_ADVANCED_LEVERAGE,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO_ADVANCED_LEVERAGE, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }

--- a/test/strategies/SiAL.Upgrade.Sonic.t.sol
+++ b/test/strategies/SiAL.Upgrade.Sonic.t.sol
@@ -6,6 +6,8 @@ import {IPlatform} from "../../src/interfaces/IPlatform.sol";
 import {IFactory} from "../../src/interfaces/IFactory.sol";
 import {StrategyIdLib} from "../../src/strategies/libs/StrategyIdLib.sol";
 import {SiloAdvancedLeverageStrategy} from "../../src/strategies/SiloAdvancedLeverageStrategy.sol";
+import {Factory} from "../../src/core/Factory.sol";
+import {IProxy} from "../../src/interfaces/IProxy.sol";
 
 contract SiALUpgradeTest is Test {
     address public constant PLATFORM = 0x4Aca671A420eEB58ecafE83700686a2AD06b20D8;
@@ -14,6 +16,8 @@ contract SiALUpgradeTest is Test {
     constructor() {
         vm.selectFork(vm.createFork(vm.envString("SONIC_RPC_URL")));
         vm.rollFork(13624880); // Mar-14-2025 07:49:27 AM +UTC
+
+        _upgradeFactory(); // upgrade to Factory v2.0.0
     }
 
     function testSiALUpgrade() public {
@@ -35,5 +39,17 @@ contract SiALUpgradeTest is Test {
         SiloAdvancedLeverageStrategy(payable(STRATEGY)).setUniversalParams(params, addresses);
         (params, addresses) = SiloAdvancedLeverageStrategy(payable(STRATEGY)).getUniversalParams();
         assertEq(params[0], 90_00);
+    }
+
+    function _upgradeFactory() internal {
+        // deploy new Factory implementation
+        address newImpl = address(new Factory());
+
+        // get the proxy address for the factory
+        address factoryProxy = address(IPlatform(PLATFORM).factory());
+
+        // prank as the platform because only it can upgrade
+        vm.prank(PLATFORM);
+        IProxy(factoryProxy).upgrade(newImpl);
     }
 }

--- a/test/strategies/SiAL.Upgrade.Sonic.t.sol
+++ b/test/strategies/SiAL.Upgrade.Sonic.t.sol
@@ -23,17 +23,7 @@ contract SiALUpgradeTest is Test {
         // deploy new impl and upgrade
         address strategyImplementation = address(new SiloAdvancedLeverageStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO_ADVANCED_LEVERAGE,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO_ADVANCED_LEVERAGE, strategyImplementation);
 
         factory.upgradeStrategyProxy(STRATEGY);
 

--- a/test/strategies/SiAL.Upgrade2.Sonic.t.sol
+++ b/test/strategies/SiAL.Upgrade2.Sonic.t.sol
@@ -631,17 +631,7 @@ contract SiALUpgrade2Test is Test {
     function _upgradeStrategy(address strategyAddress) internal {
         address strategyImplementation = address(new SiloAdvancedLeverageStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO_ADVANCED_LEVERAGE,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO_ADVANCED_LEVERAGE, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }
@@ -649,15 +639,7 @@ contract SiALUpgrade2Test is Test {
     function _upgradeVault(address vaultAddress) internal {
         address vaultImplementation = address(new CVault());
         vm.prank(multisig);
-        factory.setVaultConfig(
-            IFactory.VaultConfig({
-                vaultType: VaultTypeLib.COMPOUNDING,
-                implementation: vaultImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                buildingPrice: 1e10
-            })
-        );
+        factory.setVaultImplementation(VaultTypeLib.COMPOUNDING, vaultImplementation);
 
         factory.upgradeVaultProxy(vaultAddress);
     }

--- a/test/strategies/SiAL.Upgrade2.Sonic.t.sol
+++ b/test/strategies/SiAL.Upgrade2.Sonic.t.sol
@@ -15,6 +15,8 @@ import {SiloAdvancedLeverageStrategy} from "../../src/strategies/SiloAdvancedLev
 import {CVault} from "../../src/core/vaults/CVault.sol";
 import {VaultTypeLib} from "../../src/core/libs/VaultTypeLib.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+import {Factory} from "../../src/core/Factory.sol";
+import {IProxy} from "../../src/interfaces/IProxy.sol";
 
 /// @notice #254: Fix decreasing LTV on exits
 contract SiALUpgrade2Test is Test {
@@ -64,6 +66,8 @@ contract SiALUpgrade2Test is Test {
 
         factory = IFactory(IPlatform(PLATFORM).factory());
         multisig = IPlatform(PLATFORM).multisig();
+
+        _upgradeFactory(); // upgrade to Factory v2.0.0
     }
 
     //region -------------------------- Check flash loan kinds
@@ -677,6 +681,21 @@ contract SiALUpgrade2Test is Test {
 
     function _getPositiveDiffPercent4(uint x, uint y) internal pure returns (uint) {
         return x > y ? (x - y) * 100_00 / x : 0;
+    }
+
+    function _upgradeFactory() internal {
+        // deploy new Factory implementation
+        address newImpl = address(new Factory());
+
+        // get the proxy address for the factory
+        address factoryProxy = address(IPlatform(PLATFORM).factory());
+
+        // prank as the platform because only it can upgrade
+        vm.prank(PLATFORM);
+        IProxy(factoryProxy).upgrade(newImpl);
+
+        // refresh the factory instance to point to the proxy (now using new impl)
+        factory = IFactory(factoryProxy);
     }
     //endregion -------------------------- Auxiliary functions
 }

--- a/test/strategies/SiALMF.Upgrade.Sonic.t.sol
+++ b/test/strategies/SiALMF.Upgrade.Sonic.t.sol
@@ -213,17 +213,7 @@ contract SiALMFUpgradeTest is Test {
     function _upgradeStrategy() internal {
         address strategyImplementation = address(new SiloALMFStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO_ALMF_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO_ALMF_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(address(strategy));
     }
@@ -232,15 +222,7 @@ contract SiALMFUpgradeTest is Test {
         // deploy new impl and upgrade
         address vaultImplementation = address(new CVault());
         vm.prank(multisig);
-        factory.setVaultConfig(
-            IFactory.VaultConfig({
-                vaultType: VaultTypeLib.COMPOUNDING,
-                implementation: vaultImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                buildingPrice: 1e10
-            })
-        );
+        factory.setVaultImplementation(VaultTypeLib.COMPOUNDING, vaultImplementation);
 
         factory.upgradeVaultProxy(vault_);
     }
@@ -304,15 +286,7 @@ contract SiALMFUpgradeTest is Test {
         // deploy new impl and upgrade
         address vaultImplementation = address(new CVault());
         vm.prank(multisig);
-        factory.setVaultConfig(
-            IFactory.VaultConfig({
-                vaultType: VaultTypeLib.COMPOUNDING,
-                implementation: vaultImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                buildingPrice: 1e10
-            })
-        );
+        factory.setVaultImplementation(VaultTypeLib.COMPOUNDING, vaultImplementation);
         factory.upgradeVaultProxy(address(vault));
     }
 

--- a/test/strategies/SiALMF.Upgrade.scUsd.Sonic.t.sol
+++ b/test/strategies/SiALMF.Upgrade.scUsd.Sonic.t.sol
@@ -132,17 +132,7 @@ contract SiALMFUpgradeScUsdTest is Test {
     function _upgradeALMFStrategy(address strategy_) internal {
         address strategyImplementation = address(new SiloALMFStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO_ALMF_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO_ALMF_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategy_);
     }
@@ -150,17 +140,7 @@ contract SiALMFUpgradeScUsdTest is Test {
     function _upgradeSMFStrategy(address strategy_) internal {
         address strategyImplementation = address(new SiloManagedFarmStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO_MANAGED_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO_MANAGED_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategy_);
     }
@@ -224,15 +204,7 @@ contract SiALMFUpgradeScUsdTest is Test {
         // deploy new impl and upgrade
         address vaultImplementation = address(new CVault());
         vm.prank(multisig);
-        factory.setVaultConfig(
-            IFactory.VaultConfig({
-                vaultType: VaultTypeLib.COMPOUNDING,
-                implementation: vaultImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                buildingPrice: 1e10
-            })
-        );
+        factory.setVaultImplementation(VaultTypeLib.COMPOUNDING, vaultImplementation);
         factory.upgradeVaultProxy(vault_);
     }
 

--- a/test/strategies/SiALMF.Upgrade.scUsd.Sonic.t.sol
+++ b/test/strategies/SiALMF.Upgrade.scUsd.Sonic.t.sol
@@ -24,6 +24,8 @@ import {VaultTypeLib} from "../../src/core/libs/VaultTypeLib.sol";
 import {Test} from "forge-std/Test.sol";
 import {MetaVaultAdapter} from "../../src/adapters/MetaVaultAdapter.sol";
 import {SiloManagedFarmStrategy} from "../../src/strategies/SiloManagedFarmStrategy.sol";
+import {Factory} from "../../src/core/Factory.sol";
+import {IProxy} from "../../src/interfaces/IProxy.sol";
 
 /// @notice Fix a problem in MetaVaultAdapter that produced a false-positive ExceedSlippage error
 contract SiALMFUpgradeScUsdTest is Test {
@@ -67,6 +69,7 @@ contract SiALMFUpgradeScUsdTest is Test {
         _upgradePlatform(address(priceReader));
         _upgradeMetaVault(SonicConstantsLib.METAVAULT_METAUSD);
         //        _upgradeWrappedMetaVault();
+        _upgradeFactory(); // upgrade to Factory v2.0.0
         _upgradeCVault(address(vault));
 
         _upgradeCVault(SonicConstantsLib.VAULT_C_WMETAUSD_scUSD_125);
@@ -386,6 +389,21 @@ contract SiALMFUpgradeScUsdTest is Test {
         //        for (uint i; i < current.length; ++i) {
         //            console.log("i, current, target", i, current[i], props[i]);
         //        }
+    }
+
+    function _upgradeFactory() internal {
+        // deploy new Factory implementation
+        address newImpl = address(new Factory());
+
+        // get the proxy address for the factory
+        address factoryProxy = address(IPlatform(PLATFORM).factory());
+
+        // prank as the platform because only it can upgrade
+        vm.prank(PLATFORM);
+        IProxy(factoryProxy).upgrade(newImpl);
+
+        // refresh the factory instance to point to the proxy (now using new impl)
+        factory = IFactory(factoryProxy);
     }
     //endregion ------------------------------------ Helpers
 }

--- a/test/strategies/SiF.Upgrade.Sonic.t.sol
+++ b/test/strategies/SiF.Upgrade.Sonic.t.sol
@@ -116,15 +116,7 @@ contract SiFUpgradeTest is Test {
         // deploy new impl and upgrade
         address vaultImplementation = address(new CVault());
         vm.prank(multisig);
-        factory.setVaultConfig(
-            IFactory.VaultConfig({
-                vaultType: VaultTypeLib.COMPOUNDING,
-                implementation: vaultImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                buildingPrice: 1e10
-            })
-        );
+        factory.setVaultImplementation(VaultTypeLib.COMPOUNDING, vaultImplementation);
 
         factory.upgradeVaultProxy(vault);
     }
@@ -134,17 +126,7 @@ contract SiFUpgradeTest is Test {
 
         address strategyImplementation = address(new SiloFarmStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }

--- a/test/strategies/SiL.LeverageDebug.Sonic.t.sol
+++ b/test/strategies/SiL.LeverageDebug.Sonic.t.sol
@@ -122,17 +122,7 @@ contract SiloLeverageLendingStrategyDebugTest is Test {
 
     function _upgrade() internal {
         address strategyImplementation = address(new SiloLeverageStrategy());
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO_LEVERAGE,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: false,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO_LEVERAGE, strategyImplementation);
         factory.upgradeStrategyProxy(STRATEGY);
     }
 }

--- a/test/strategies/SiL.Upgrade.Sonic.t.sol
+++ b/test/strategies/SiL.Upgrade.Sonic.t.sol
@@ -26,17 +26,7 @@ contract SiLUpgradeTest is Test {
         // deploy new impl and upgrade
         address strategyImplementation = address(new SiloLeverageStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO_LEVERAGE,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: false,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO_LEVERAGE, strategyImplementation);
 
         factory.upgradeStrategyProxy(STRATEGY);
 

--- a/test/strategies/SiL.Upgrade2.Sonic.t.sol
+++ b/test/strategies/SiL.Upgrade2.Sonic.t.sol
@@ -634,17 +634,7 @@ contract SiLUpgradeTest2 is Test {
     function _upgradeStrategy(address strategyAddress) internal {
         address strategyImplementation = address(new SiloLeverageStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO_LEVERAGE,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO_LEVERAGE, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }

--- a/test/strategies/SiL.Upgrade2.Sonic.t.sol
+++ b/test/strategies/SiL.Upgrade2.Sonic.t.sol
@@ -11,6 +11,8 @@ import {IFactory} from "../../src/interfaces/IFactory.sol";
 import {StrategyIdLib} from "../../src/strategies/libs/StrategyIdLib.sol";
 import {SiloLeverageStrategy} from "../../src/strategies/SiloLeverageStrategy.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+import {Factory} from "../../src/core/Factory.sol";
+import {IProxy} from "../../src/interfaces/IProxy.sol";
 
 contract SiLUpgradeTest2 is Test {
     address public constant PLATFORM = 0x4Aca671A420eEB58ecafE83700686a2AD06b20D8;
@@ -58,6 +60,7 @@ contract SiLUpgradeTest2 is Test {
 
         factory = IFactory(IPlatform(PLATFORM).factory());
         multisig = IPlatform(PLATFORM).multisig();
+        _upgradeFactory(); // upgrade to Factory v2.0.0
     }
 
     //region -------------------------- Use various flash loan vaults
@@ -673,6 +676,21 @@ contract SiLUpgradeTest2 is Test {
 
     function _getPositiveDiffPercent4(uint x, uint y) internal pure returns (uint) {
         return x > y ? (x - y) * 100_00 / x : 0;
+    }
+
+    function _upgradeFactory() internal {
+        // deploy new Factory implementation
+        address newImpl = address(new Factory());
+
+        // get the proxy address for the factory
+        address factoryProxy = address(IPlatform(PLATFORM).factory());
+
+        // prank as the platform because only it can upgrade
+        vm.prank(PLATFORM);
+        IProxy(factoryProxy).upgrade(newImpl);
+
+        // refresh the factory instance to point to the proxy (now using new impl)
+        factory = IFactory(factoryProxy);
     }
     //endregion -------------------------- Auxiliary functions
 }

--- a/test/strategies/SiMF.Upgrade.Sonic.t.sol
+++ b/test/strategies/SiMF.Upgrade.Sonic.t.sol
@@ -118,15 +118,7 @@ contract SiMFUpgradeTest is Test {
         // deploy new impl and upgrade
         address vaultImplementation = address(new CVault());
         vm.prank(multisig);
-        factory.setVaultConfig(
-            IFactory.VaultConfig({
-                vaultType: VaultTypeLib.COMPOUNDING,
-                implementation: vaultImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                buildingPrice: 1e10
-            })
-        );
+        factory.setVaultImplementation(VaultTypeLib.COMPOUNDING, vaultImplementation);
 
         factory.upgradeVaultProxy(vault);
     }
@@ -136,17 +128,7 @@ contract SiMFUpgradeTest is Test {
 
         address strategyImplementation = address(new SiloManagedFarmStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO_MANAGED_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO_MANAGED_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }

--- a/test/strategies/SiMF.Upgrade.Sonic.t.sol
+++ b/test/strategies/SiMF.Upgrade.Sonic.t.sol
@@ -17,6 +17,8 @@ import {StrategyIdLib} from "../../src/strategies/libs/StrategyIdLib.sol";
 import {VaultTypeLib} from "../../src/core/libs/VaultTypeLib.sol";
 import {Test} from "forge-std/Test.sol";
 import {SiloManagedFarmStrategy} from "../../src/strategies/SiloManagedFarmStrategy.sol";
+import {Factory} from "../../src/core/Factory.sol";
+import {IProxy} from "../../src/interfaces/IProxy.sol";
 
 contract SiMFUpgradeTest is Test {
     uint public constant FORK_BLOCK = 33508152; // Jun-12-2025 05:49:24 AM +UTC
@@ -36,6 +38,7 @@ contract SiMFUpgradeTest is Test {
         multisig = IPlatform(PLATFORM).multisig();
 
         priceReader = IPriceReader(IPlatform(PLATFORM).priceReader());
+        _upgradeFactory(); // upgrade to Factory v2.0.0
     }
 
     /// @notice #326: Add maxWithdrawAssets and poolTvl to IStrategy
@@ -131,6 +134,18 @@ contract SiMFUpgradeTest is Test {
         factory.setStrategyImplementation(StrategyIdLib.SILO_MANAGED_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
+    }
+
+    function _upgradeFactory() internal {
+        // deploy new Factory implementation
+        address newImpl = address(new Factory());
+
+        // get the proxy address for the factory
+        address factoryProxy = address(IPlatform(PLATFORM).factory());
+
+        // prank as the platform because only it can upgrade
+        vm.prank(PLATFORM);
+        IProxy(factoryProxy).upgrade(newImpl);
     }
     //endregion ------------------------------ Auxiliary Functions
 }

--- a/test/strategies/SiMF.Upgrade.xSilo.Sonic.t.sol
+++ b/test/strategies/SiMF.Upgrade.xSilo.Sonic.t.sol
@@ -24,6 +24,8 @@ import {SonicConstantsLib} from "../../chains/sonic/SonicConstantsLib.sol";
 import {StrategyIdLib} from "../../src/strategies/libs/StrategyIdLib.sol";
 import {VaultTypeLib} from "../../src/core/libs/VaultTypeLib.sol";
 import {Test} from "forge-std/Test.sol";
+import {Factory} from "../../src/core/Factory.sol";
+import {IProxy} from "../../src/interfaces/IProxy.sol";
 
 /// @notice #335: Add support of xSilo in SiMF strategy
 contract SiMFUpgradeXSiloTest is Test {
@@ -45,6 +47,7 @@ contract SiMFUpgradeXSiloTest is Test {
         multisig = IPlatform(PLATFORM).multisig();
 
         priceReader = IPriceReader(IPlatform(PLATFORM).priceReader());
+        _upgradeFactory(); // upgrade to Factory v2.0.0
     }
 
     /// @notice #335: Add support of xSilo in SiMF strategy
@@ -234,6 +237,18 @@ contract SiMFUpgradeXSiloTest is Test {
 
     function _getPositiveDiffPercent4(uint x, uint y) internal pure returns (uint) {
         return x > y ? (x - y) * 100_00 / x : 0;
+    }
+
+    function _upgradeFactory() internal {
+        // deploy new Factory implementation
+        address newImpl = address(new Factory());
+
+        // get the proxy address for the factory
+        address factoryProxy = address(IPlatform(PLATFORM).factory());
+
+        // prank as the platform because only it can upgrade
+        vm.prank(PLATFORM);
+        IProxy(factoryProxy).upgrade(newImpl);
     }
     //endregion ------------------------------ Auxiliary Functions
 }

--- a/test/strategies/SiMF.Upgrade.xSilo.Sonic.t.sol
+++ b/test/strategies/SiMF.Upgrade.xSilo.Sonic.t.sol
@@ -167,15 +167,7 @@ contract SiMFUpgradeXSiloTest is Test {
         // deploy new impl and upgrade
         address vaultImplementation = address(new CVault());
         vm.prank(multisig);
-        factory.setVaultConfig(
-            IFactory.VaultConfig({
-                vaultType: VaultTypeLib.COMPOUNDING,
-                implementation: vaultImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                buildingPrice: 1e10
-            })
-        );
+        factory.setVaultImplementation(VaultTypeLib.COMPOUNDING, vaultImplementation);
 
         factory.upgradeVaultProxy(vault);
     }
@@ -185,17 +177,7 @@ contract SiMFUpgradeXSiloTest is Test {
 
         address strategyImplementation = address(new SiloManagedFarmStrategy());
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.SILO_MANAGED_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.SILO_MANAGED_FARM, strategyImplementation);
 
         factory.upgradeStrategyProxy(strategyAddress);
     }

--- a/test/strategies/SiMMF.Upgrade.Sonic.t.sol
+++ b/test/strategies/SiMMF.Upgrade.Sonic.t.sol
@@ -8,6 +8,8 @@ import {IFactory} from "../../src/interfaces/IFactory.sol";
 import {StrategyIdLib} from "../../src/strategies/libs/StrategyIdLib.sol";
 import {SiloManagedMerklFarmStrategy, CommonLib} from "../../src/strategies/SiloManagedMerklFarmStrategy.sol";
 import {SonicConstantsLib} from "../../chains/sonic/SonicConstantsLib.sol";
+import {Factory} from "../../src/core/Factory.sol";
+import {IProxy} from "../../src/interfaces/IProxy.sol";
 
 contract SiMMFUpgradeTest is Test {
     address public constant PLATFORM = SonicConstantsLib.PLATFORM;
@@ -18,6 +20,7 @@ contract SiMMFUpgradeTest is Test {
         vm.selectFork(vm.createFork(vm.envString("SONIC_RPC_URL")));
         vm.rollFork(47900000); // Sep-23-2025 12:01:57 PM +UTC
         vault = IStrategy(STRATEGY).vault();
+        _upgradeFactory(); // upgrade to Factory v2.0.0
     }
 
     function testSiMMFUpgrade() public {
@@ -50,5 +53,17 @@ contract SiMMFUpgradeTest is Test {
         IStrategy(STRATEGY).setProtocols(protocols);
         assertEq(IStrategy(STRATEGY).protocols().length, 2);
         assertEq(CommonLib.eq(IStrategy(STRATEGY).protocols()[1], "org2:p2"), true);
+    }
+
+    function _upgradeFactory() internal {
+        // deploy new Factory implementation
+        address newImpl = address(new Factory());
+
+        // get the proxy address for the factory
+        address factoryProxy = address(IPlatform(PLATFORM).factory());
+
+        // prank as the platform because only it can upgrade
+        vm.prank(PLATFORM);
+        IProxy(factoryProxy).upgrade(newImpl);
     }
 }

--- a/test/strategies/TPF.Upgrade.Real.t.sol
+++ b/test/strategies/TPF.Upgrade.Real.t.sol
@@ -35,17 +35,7 @@ contract TPFUpgradeTest is Test {
         vm.prank(multisig);
         IPlatform(PLATFORM).addOperator(multisig);
         vm.prank(multisig);
-        factory.setStrategyLogicConfig(
-            IFactory.StrategyLogicConfig({
-                id: StrategyIdLib.TRIDENT_PEARL_FARM,
-                implementation: strategyImplementation,
-                deployAllowed: true,
-                upgradeAllowed: true,
-                farming: true,
-                tokenId: 0
-            }),
-            address(this)
-        );
+        factory.setStrategyImplementation(StrategyIdLib.TRIDENT_PEARL_FARM, strategyImplementation);
         factory.upgradeStrategyProxy(STRATEGY);
 
         vaultManager.vaults();


### PR DESCRIPTION
* [x] use `IFactory.setVaultImplementation` and `IFactory.setStrategyImplementation` in all tests (with Factory upgrade)
* [x] remove `IFactory.setVaultConfig` and `IFactory.setStrategyLogicConfig` from Factory with Factory version bumping
* [x] Remove IFactory.setVaultConfig and IFactory.setStrategyLogicConfig from codebase